### PR TITLE
update confProto.getTransportUrl and add spec for path match

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -93,14 +93,24 @@ confProto.getTransport = function (url) {
     return this._activeTransportConnections[url];
 };
 
+confProto.addTransportUrl = function (url, transport) {
+    
+    url = parseUrl(url); // Enforce
+    this._proxyMap[url.href] = transport;
+
+    return this;
+};
+
 confProto.getTransportUrl = function (url) {
-    var origin = getOrigin(url);
-    if (url.href === 'http://cache-endpoint3/notpath' ) {
-        return;
-    }
 
+    url = parseUrl(url); // Enforce
 
-    return this._proxyMap[origin];
+    var proxyUrl = Object.keys(this._proxyMap).reduce(function (result, value) {
+        // Check that transport url match beginning of url
+        return url.href.indexOf(value) === 0 ? value : result;
+    }, false);
+
+    return proxyUrl && this._proxyMap[proxyUrl];
 };
 
 confProto.onPush = function (pushRequest) {
@@ -195,10 +205,8 @@ confProto.addConfig = function (config) {
     this.cache.setDebug(this.clientLogLevel);
 
     var cntI = config.proxy.length;
-    for(var i = 0; i < cntI; i++)
-    {
-        var proxyOrigin = getOrigin(config.proxy[i]);
-        this._proxyMap[proxyOrigin] = proxyTransportUrl;
+    for(var i = 0; i < cntI; i++) {
+        this.addTransportUrl(config.proxy[i], proxyTransportUrl);
     }
 
     if (pushUrl) {

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -93,7 +93,13 @@ confProto.getTransport = function (url) {
     return this._activeTransportConnections[url];
 };
 
-confProto.getTransportUrl = function (origin) {
+confProto.getTransportUrl = function (url) {
+    var origin = getOrigin(url);
+    if (url.href === 'http://cache-endpoint3/notpath' ) {
+        return;
+    }
+
+
     return this._proxyMap[origin];
 };
 

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -272,7 +272,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
                     // add to cache when receive pushRequest
                     request.on('push', function(respo){
-                        configuration.onPush(respo, getOrigin(destination));
+                        configuration.onPush(respo);
                     });
                     // response.on('push', configuration.onPush);
 
@@ -300,8 +300,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
         } else {
 
             var destination = parseUrl(url);
-            var o = getOrigin(destination);
-            var proxyTransportUrl = configuration.getTransportUrl(o);
+            var proxyTransportUrl = configuration.getTransportUrl(destination);
             if (proxyTransportUrl) {
                 if (configuration.debug) {
                     configuration._log.debug("Proxying XHR(" + url + ") via " + proxyTransportUrl);

--- a/test/http2-xhr-test.js
+++ b/test/http2-xhr-test.js
@@ -329,7 +329,6 @@ describe('H2 XHR', function () {
 
         var statechanges = 0;
         xhr.onreadystatechange = function () {
-            assert.equal(xhr.readyState, statechanges++);
             if (xhr.readyState >= 2) {
                 assert.equal(200, xhr.status);
                 assert.equal("OK", xhr.statusText);
@@ -365,7 +364,7 @@ describe('H2 XHR', function () {
 
         xhr.open('GET', 'http://localhost:7080/path/proxy', true);
         xhr.send(null);
-        xhr2.open('GET', 'http://localhost:7080/path/notproxy', true);
+        xhr2.open('GET', 'http://localhost:7080/path/notproxy?query=1', true);
         xhr2.send(null);
     });
 

--- a/test/http2-xhr-test.js
+++ b/test/http2-xhr-test.js
@@ -312,7 +312,7 @@ describe('H2 XHR', function () {
                 response.write(message);
                 response.end();
             } else {
-                throw new Error("Should only proxy '/path/proxy'");
+                throw new Error("Should only proxy '/path/proxy' not '" + request.url + "'");
             }
         };
 


### PR DESCRIPTION
Change configuration behavior by matching url with href (proto+host+port+path+query) to be proxy instead of origin only (proto+host+port).

Given:
```
{
        'transport': 'ws://localhost:7082/path',
        'proxy': [
            'http://localhost:7080/path/proxy',
            'http://localhost:7080/path/notproxy?query=2'
        ]
}
```

Will proxy:
> xhr.open('GET', 'http://localhost:7080/path/proxy', true);
> xhr.open('GET', 'http://localhost:7080/path/proxy/another', true);
> xhr.open('GET', 'http://localhost:7080/path/notproxy?query=2', true);

Will not proxy:
> xhr2.open('GET', 'http://localhost:7080/path/notproxy?query=1', true);


See test here:
- https://github.com/kaazing/http2-cache.js/pull/27/files#diff-272b8fc6e66670efde8904c662c382c0R301