### PR TITLE
implement partial FormData support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -118,7 +118,6 @@
     "indent"        : 4,         // Specify indentation spacing
     "mocha": true,
     "globals": {
-      "console": false,
       "WebSocket": false,
       "Buffer": false,
       "require": false,

--- a/.jshintrc
+++ b/.jshintrc
@@ -118,13 +118,14 @@
     "indent"        : 4,         // Specify indentation spacing
     "mocha": true,
     "globals": {
-        "console": false,
+      "console": false,
       "WebSocket": false,
       "Buffer": false,
       "require": false,
       "exports": false,
       "module": false,
       "FormData": true,
+      "XMLHttpRequest": true,
       "Promise": true,
       "WeakMap": true,
       "Map": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -18,7 +18,7 @@
     //
     // @author http://michael.haschke.biz/
     // @license http://unlicense.org/
-
+    "esversion": 6,
     // == Enforcing Options ===============================================
     //
     // These options tell JSHint to be more strict towards your code. Use
@@ -118,13 +118,14 @@
     "indent"        : 4,         // Specify indentation spacing
     "mocha": true,
     "globals": {
-
+        "console": false,
       "WebSocket": false,
       "Buffer": false,
       "require": false,
       "exports": false,
       "module": false,
-
+      "FormData": true,
+      "Promise": true,
       "WeakMap": true,
       "Map": true,
       "Set": true

--- a/lib/form-data.js
+++ b/lib/form-data.js
@@ -1,0 +1,18 @@
+var xhr = require('./xhr');
+
+function FormData() {
+	this.data = [];
+}
+
+FormData.prototype.append = function(key, value) {
+	this.data.push([key, value]);
+};
+
+
+FormData.prototype.entries = function() {
+	return this.data;
+};
+
+module.exports = {
+    FormData: FormData
+};

--- a/lib/http2-cache.js
+++ b/lib/http2-cache.js
@@ -4,7 +4,7 @@
         enableXHROverH2 = require('./xhr.js').enableXHROverH2;
 
     var configuration = new Configuration({
-    	debug: true // true='info' or (info|debug|trace)
+    	debug: false // true='info' or (info|debug|trace)
     });
     enableXHROverH2(XMLHttpRequest, configuration);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -185,7 +185,7 @@ var caseInsensitiveEquals = function (str1, str2) {
     return str1.toUpperCase() === str2.toUpperCase();
 };
 
-var serializeXhrBody = function (body) {
+var serializeXhrBody = function (xhrInfo, body) {
     if (
         typeof FormData !== 'undefined' &&
             body instanceof FormData
@@ -198,6 +198,8 @@ var serializeXhrBody = function (body) {
         }
 
         body = bodyParts.join('&');
+        
+        //xhrInfo.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     }
 
     return body;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -58,7 +58,7 @@ var defaultPort = function (u, port) {
     return u.protocol + '//' + u.hostname + ':' + port + parse.path;
 };
 
-function Utf8ArrayToStr(array) {
+var Utf8ArrayToStr = function (array) {
     var out, i, len;
     out = "";
     len = array.length;
@@ -127,6 +127,24 @@ var caseInsensitiveEquals = function (str1, str2) {
     return str1.toUpperCase() === str2.toUpperCase();
 };
 
+var serializeXhrBody = function (body) {
+    if (
+        typeof FormData !== 'undefined' &&
+            body instanceof FormData
+    ) {
+
+        // Display the key/value pairs
+        var bodyParts = [];
+        for(var partPair of body.entries()) {
+            bodyParts.push(encodeURIComponent(partPair[0]) + '=' + encodeURIComponent(partPair[1]));
+        }
+
+        body = bodyParts.join('&');
+    }
+
+    return body;
+};
+
 module.exports = {
     parseUrl: parseUrl,
     redefine: redefine,
@@ -136,6 +154,7 @@ module.exports = {
     getOrigin: getOrigin,
     dataToType: dataToType,
     defaultPort: defaultPort,
+    serializeXhrBody: serializeXhrBody,
     caseInsensitiveEquals: caseInsensitiveEquals,
     Utf8ArrayToStr: Utf8ArrayToStr
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -98,7 +98,7 @@ var Utf8ArrayToStr = function (array) {
 
     return out;
     /* jshint ignore:end */
-}
+};
 
 var dataToType = function (data, type) {
     // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -1,5 +1,4 @@
 var http2 = require('http2'),
-    FormData = require('./form-data').FormData,
     redefine = require('./utils').redefine,
     definePrivate = require('./utils').definePrivate,
     dataToType = require('./utils').dataToType,

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -304,7 +304,6 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 configuration._log.debug("Delaying XHR(" + url + ") until configuration completes");
             }
             configuration.once('completed', function () {
-                console.log(body);
                 self.send(body);
             });
         } else {

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -1,10 +1,12 @@
 var http2 = require('http2'),
+    FormData = require('./form-data').FormData,
     redefine = require('./utils').redefine,
     definePrivate = require('./utils').definePrivate,
     dataToType = require('./utils').dataToType,
     defaultPort = require('./utils').defaultPort,
     RequestInfo = require('./cache.js').RequestInfo,
     parseUrl = require('./utils').parseUrl,
+    serializeXhrBody = require('./utils').serializeXhrBody,
     getOrigin = require('./utils').getOrigin,
     InvalidStateError = require('./errors.js').InvalidStateError,
     XhrInfo = require('./xhr-info.js'),
@@ -204,6 +206,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 } else {
                     // Need to make the request your self
                     if (body) {
+
                         // https://xhr.spec.whatwg.org/#the-send%28%29-method
                         if (
                             typeof HTMLElement !== 'undefined' &&
@@ -216,10 +219,13 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                                 xhrInfo.get(self, 'headers').set('content-type', 'text/html; charset=utf-8');
                             }
                         } else {
+                            // Set default encoding
+                            // TODO use document encoding
                             if (!xhrInfo.get(self, 'headers').has('content-encoding')) {
                                 xhrInfo.get(self, 'headers').set('content-encoding', 'UTF-8');
                             }
                         }
+
                         // only other option in spec is a String
                         // inject content-length TODO remove this as should not be required
                         xhrInfo.get(self, 'headers').set('content-length', body.toString().length);
@@ -290,11 +296,16 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
     redefine(xhrProto, 'send', function (body) {
         var url = xhrInfo.get(this, 'url');
         var self = this;
+
+        // Also fix support for node-http2 FormData
+        body = serializeXhrBody(body);
+
         if (configuration.isConfiguring()) {
             if (configuration.debug) {
                 configuration._log.debug("Delaying XHR(" + url + ") until configuration completes");
             }
             configuration.once('completed', function () {
+                console.log(body);
                 self.send(body);
             });
         } else {

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -322,7 +322,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
         var self = this;
 
         // Also fix support for node-http2 FormData
-        body = serializeXhrBody(body);
+        body = serializeXhrBody(xhrInfo, body);
 
         if (configuration.isConfiguring()) {
             if (configuration.debug) {
@@ -344,12 +344,19 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 if (configuration.debug) {
                     configuration._log.debug("Sending XHR(" + url + ") via native stack");
                 }
+
                 this._open(xhrInfo.get(this, 'method'),
                     url,
                     xhrInfo.get(this, 'async'),
                     xhrInfo.get(this, 'username'),
-                    xhrInfo.get(this, 'password'));
-                // TODO set headers
+                    xhrInfo.get(this, 'password')
+                );
+
+                var headers = xhrInfo.get(this, 'headers');
+                headers.forEach(function (value, key, headers) {  
+                    this._setRequestHeader(key, value);                  
+                }, this);
+
                 this._send(body);
             }
 

--- a/test/http2-xhr-test.js
+++ b/test/http2-xhr-test.js
@@ -1,11 +1,9 @@
 /* global console */
 
-/* jshint ignore:start */
 XMLHttpRequest = require("xhr2").XMLHttpRequest;
-/* jshint ignore:end */
-require("../lib/http2-cache");
-
 FormData = require("../lib/form-data").FormData;
+
+require("../lib/http2-cache");
 
 var assert = require('assert'),
     http = require('http'),


### PR DESCRIPTION
Allow FormData to Socket.

Example:
```
var formData = new FormData();
formData.append('username', 'Chris');
formData.append('username', 'Bob');
formData.append('gender', 'male');  

xhr.send(formData);
```

Also fix missing headers on non proxy xhr.