### PR TITLE
Fix headers reference to use Map#get

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -95,7 +95,7 @@ function isCacheableResponse(response) {
         var directives = parseCacheControl(cacheControlHeaders);
         if (directives['max-age']) {
             return true;
-        } else if(directives['stale-while-revalidate']){
+        } else if (directives['stale-while-revalidate']) {
             return true;
         }
     }
@@ -106,7 +106,7 @@ cp.match = function (requestInfo/*, options*/) {
     var self = this;
     return new Promise(function (resolve/*, reject*/) {
         var response = null;
-        var requestCacheDirectives = parseCacheControl(requestInfo.headers['cache-control']);
+        var requestCacheDirectives = parseCacheControl(requestInfo.headers.get('cache-control'));
         if (requestCacheDirectives === null || !requestCacheDirectives['no-cache']) {
             var candidate = self._requestInfoToResponse.get(requestInfo.hash);
             if (candidate && satisfiesRequest(requestInfo, candidate) && !isExpired(candidate, new Date().getTime())) {


### PR DESCRIPTION
Request.info.headers is a Map so properties cannot be retrieved via reference and must use get.