### PR TITLE
implement requestHashHeaders

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -70,21 +70,30 @@ function getRequestInfoHeaders(requestInfo, headers) {
     return headers;
 }
 
-var requestHashHeaders = ['Authorization'];
+var privateCacheHashHeaders = ['Authorization'];
 var RequestInfo = function (method, href, headers) {
     var self = this;
     self.method = method;
     self.href = href;
     self.headers = getRequestInfoHeaders(self, headers);
-    self.cacheDirectives = parseCacheControl(getCacheControlHeaders(self));
+
+    var cacheControlHeader = getCacheControlHeaders(self)
+    self.cacheDirectives = parseCacheControl(cacheControlHeader);
 
     self.hash = self.method + '^' + self.href;
 
-    requestHashHeaders.forEach(function (requestHashHeader) {
-        if (self.headers.hasOwnProperty(requestHashHeader)) {
-            self.hash += self.headers[requestHashHeader];
-        }
-    });
+    // Use requestHashHeaders only if cacheControlHeader not public
+    // TODO cacheDirectives default ?
+    if (
+        self.cacheDirectives && 
+            self.cacheDirectives.public !== true
+    ) {
+        privateCacheHashHeaders.forEach(function (requestHashHeader) {
+            if (self.headers.hasOwnProperty(requestHashHeader)) {
+                self.hash += self.headers[requestHashHeader];
+            }
+        });
+    }
 };
 
 // var rip = RequestInfo.prototype;

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -70,13 +70,21 @@ function getRequestInfoHeaders(requestInfo, headers) {
     return headers;
 }
 
+var requestHashHeaders = ['Authorization'];
 var RequestInfo = function (method, href, headers) {
     var self = this;
     self.method = method;
     self.href = href;
     self.headers = getRequestInfoHeaders(self, headers);
     self.cacheDirectives = parseCacheControl(getCacheControlHeaders(self));
+
     self.hash = self.method + '^' + self.href;
+
+    requestHashHeaders.forEach(function (requestHashHeader) {
+        if (self.headers.hasOwnProperty(requestHashHeader)) {
+            self.hash += self.headers[requestHashHeader];
+        }
+    });
 };
 
 // var rip = RequestInfo.prototype;
@@ -190,7 +198,6 @@ cp.put = function (requestInfo, response) {
             reject(new TypeError("Invalid requestInfo argument"))
         } else if (!isCacheableResponse(response)) {
             // Clear cache of any previous request on non cachable status
-            self._requestInfoToResponse.delete(requestInfo.hash);
             reject(new Error("Not Cacheable response"));
         } else {
             if (self._debug) {

--- a/test/http-cache-test.js
+++ b/test/http-cache-test.js
@@ -129,6 +129,72 @@ describe('http-cache', function () {
         });
     });
 
+    it('Cache update fail when Authentication header does match', function (done) {
+        var cache = new Cache();
+        var response1 = {
+            'href': 'https://example.com/',
+            'headers': {
+                'Authentication': 'MyFirstToken', 
+                'cache-control': 'max-age=1', 
+                'date': new Date()
+            },
+            'statusCode': 200
+        };
+        var requestInfo = new RequestInfo("GET", "https://example.com/", {
+            'Authentication': 'MySecondToken'
+        });
+        cache.put(requestInfo, response1).then(function () {
+            cache.match(requestInfo).then(function (r) {
+                assert.equal(r, response1);
+                done();
+            });
+        });
+    });
+
+    it('Cache update fail when Authentication header does not match', function (done) {
+        var cache = new Cache();
+        var response1 = {
+            'href': 'https://example.com/',
+            'headers': {
+                'Authentication': 'MyFirstToken', 
+                'cache-control': 'max-age=1', 
+                'date': new Date()
+            },
+            'statusCode': 200
+        };
+        var requestInfo = new RequestInfo("GET", "https://example.com/", {
+            'Authentication': 'MyFirstToken'
+        });
+        cache.put(requestInfo, response1).then(function () {
+            cache.match(requestInfo).then(function (r) {
+                assert.equal(r, response1);
+                done();
+            });
+        });
+    });
+
+    it('Cache update fail when Authentication header does not match, unless cache-control: public', function (done) {
+        var cache = new Cache();
+        var response1 = {
+            'href': 'https://example.com/',
+            'headers': {
+                'Authentication': 'MyFirstToken', 
+                'cache-control': 'public, max-age=1', 
+                'date': new Date()
+            },
+            'statusCode': 200
+        };
+        var requestInfo = new RequestInfo("GET", "https://example.com/", {
+            'Authentication': 'MySecondToken'
+        });
+        cache.put(requestInfo, response1).then(function () {
+            cache.match(requestInfo).then(function (r) {
+                assert.equal(r, response1);
+                done();
+            });
+        });
+    });
+
     it('Cache update fail when no cachable statusCode provided after a cachable statusCode and return inital cached response', function (done) {
         var cache = new Cache();
         var response1 = {
@@ -179,6 +245,10 @@ describe('http-cache', function () {
 
         header = parseCacheControl('must-revalidate, max-age=a3600');
         assert.equal(header, null);
+
+        header = parseCacheControl('public, max-age=3600');
+        assert.equal(header['public'], true);
+        assert.equal(header['max-age'], 3600);
 
         header = parseCacheControl(123);
         assert.equal(header, null);

--- a/test/http-cache-test.js
+++ b/test/http-cache-test.js
@@ -129,7 +129,7 @@ describe('http-cache', function () {
         });
     });
 
-    it('Cache update fail when no cachable statusCode provided after a cachable statusCode', function (done) {
+    it('Cache update fail when no cachable statusCode provided after a cachable statusCode and return inital cached response', function (done) {
         var cache = new Cache();
         var response1 = {
             'href': 'https://example.com/', 
@@ -154,7 +154,7 @@ describe('http-cache', function () {
 
                     // Here is check cache has been clear
                     cache.match(requestInfo).then(function (r) {
-                        assert.equal(r, null);
+                        assert.equal(r, response1);
                         done();
                     });
                 });


### PR DESCRIPTION
- [x]  Don’t serve cached response to requests where Authorization header is different.  
- [x]  Unless cache-control directive on response says Public