### PR TITLE
use current location when XHR url is missing hostname, protocol and port

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,18 @@ var parseUrl = function (href) {
     var uri = (href instanceof url.constructor) ? href : url.parse(href);
     uri.port = resolvePort(uri);
 
+
+    if (
+        uri.hostname === null &&
+            typeof window !== 'undefined'
+    ) {
+        uri.protocol = window.location.protocol;
+        uri.hostname = window.location.hostname;
+        uri.port = window.location.port;
+        uri.host = uri.hostname + ':' + uri.port;
+        uri.href = uri.protocol + "//" + uri.host + '/' + uri.href;
+    }
+
     // Define uri.origin
     uri.origin = uri.hostname + ":" + uri.port;
  

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -36,6 +36,24 @@ describe('utils', function () {
 			assert.equal(uri.host, uri.hostname + ":" + uri.port);
 			assert.equal(uri.href, url.replace(uri.hostname, uri.host));		
 		});
+
+
+		it('should add defult protocol, hostname, and port', function () {
+
+			global.window = {
+				location: {
+					hostname: 'example.com',
+					protocol: 'https:',
+					port: '8080'
+				}
+			};
+
+			var url = "path?query=1",
+				uri = parseUrl(url);
+			assert.equal(uri.port, 8080);	
+			assert.equal(uri.host, 'example.com:8080');
+			assert.equal(uri.href, "https://example.com:8080/path?query=1");
+		});
 	});	
 
 	describe('Utf8ArrayToStr', function () {


### PR DESCRIPTION
```
    	XMLHttpRequest.proxy([{
	        "push": "https://rest-accelerator.example.com:8081/event-stream",
	        "transport": "wss://rest-accelerator.example.com:8081/",
	        "clientLogLevel": "debug",
	        "proxy": [
	            // Add demos service endpoint here
	            "https://origin-server.example.com:8084/api"
	        ]
	    }]);


    	var xhr = new XMLHttpRequest();
        xhr.onreadystatechange = function() {
        	console.log(xhr.status, xhr.responseText);
        };
        // Should proxy cause current url is "https://origin-server.example.com:8084"
        xhr.open('GET', "/api/rates/USDGBP");
        xhr.send('');
```