### PR TITLE
Bugs/web socket error

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,2 +1,3 @@
 node_modules/
+e2e-test/tests.js
 index.js

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -253,7 +253,7 @@ function isExpired(candidate, currentTime) {
     return getExpireTime(candidate, cacheResponseDirectives) < currentTime;
 }
 
-cp._expireOld = function () {
+cp.clearExpired = function () {
     var self = this;
     self._requestInfoToResponses.forEach(function (candidates) {
         candidates.forEach(function (response, requestInfoHash) {
@@ -266,6 +266,13 @@ cp._expireOld = function () {
             }
         });
     });
+};
+
+/**
+ * Clear all requestInfos from revalidation.
+ */
+cp.clearRevalidates = function () {
+    this._requestInfoRevalidating = new Dict();
 };
 
 /**

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -130,11 +130,11 @@ confProto.onPush = function (pushRequest) {
 
     var requestInfo = new RequestInfo(pushRequest.method, pushRequest.href, pushRequest.headers);
     
-    // Set requestInfo revalidate state
-    // TODO pass pushRequest for future dedup pending requestInfo
-    cache.revalidate(requestInfo);
-
     pushRequest.on('response', function (response) {
+
+        // Set requestInfo revalidate state
+        // TODO pass pushRequest for future dedup pending requestInfo
+        cache.revalidate(requestInfo);
 
         // TODO match or partial move to _sendViaHttp2 xhr.js to avoid maintain both
         response.on('data', function (data) {

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -73,11 +73,32 @@ confProto.isConfiguring = function () {
 };
 
 confProto.getTransport = function (url) {
-    if (!this._activeTransportConnections[url] || !this._activeTransportConnections[url].writable) {
-        if (this.debug) {
-            this._log.info("Opening transport: " + url);
+
+    var self = this,
+        hasExistingTransport = self._activeTransportConnections.hasOwnProperty(url),
+        hasActiveTransport =  hasExistingTransport && !!self._activeTransportConnections[url].writable;
+    
+    if (
+        hasExistingTransport === false || 
+            hasActiveTransport === false
+    ) {
+
+        // Cleanup on first existing transtort re-connection attempt.
+        if (hasExistingTransport) {
+
+            if (this.debug) {
+                this._log.info("Re-Opening transport: " + url);
+            }
+
+            // Clear pending revalidates 
+            this.cache.clearRevalidates();
+
+        } else {
+            if (this.debug) {
+                this._log.info("Opening transport: " + url);
+            }            
         }
-       
+
         var parsedUrl = parseUrl(url);
         if(parsedUrl.protocol === 'ws:' || parsedUrl.protocol === 'wss:'){
             // TODO, maybe enable perMessageDeflate in production or on debug??
@@ -89,10 +110,11 @@ confProto.getTransport = function (url) {
                 'host' : parsedUrl.hostname,
                 'port' : parsedUrl.port
             });
-        }else{
+        } else {
             throw new Error('Unrecognized transport protocol: ' + parsedUrl.protocol + ', for transport: ' + url);
         }
     }
+
     return this._activeTransportConnections[url];
 };
 
@@ -128,12 +150,12 @@ confProto.onPush = function (pushRequest) {
         self._log.info("Received push promise for: " + pushRequest.href);
     }
 
+    // Set requestInfo revalidate state
+    // TODO pass pushRequest for future dedup pending requestInfo
     var requestInfo = new RequestInfo(pushRequest.method, pushRequest.href, pushRequest.headers);
-    
+
     pushRequest.on('response', function (response) {
 
-        // Set requestInfo revalidate state
-        // TODO pass pushRequest for future dedup pending requestInfo
         cache.revalidate(requestInfo);
 
         // TODO match or partial move to _sendViaHttp2 xhr.js to avoid maintain both
@@ -154,6 +176,9 @@ confProto.onPush = function (pushRequest) {
 
         response.on('error', function (e) {
             self._log.warn("Server push stream error: " + e);
+
+            // Clear requestInfo revalidate state
+            cache.validated(requestInfo);
         });
     });
 };
@@ -181,9 +206,12 @@ confProto.openH2StreamForPush = function (pushUrl, proxyTransportUrl) {
         opened = false;
         self._log.info(pushUrl + " push channel closed.");
 
+        // Clear pending revalidates 
+        self.cache.clearRevalidates();
+
         if (err) {
-            reconnectFailures.push(err);
             self._log.warn("Push channel stream error: " + err);
+            reconnectFailures.push(err);
 
             if (reconnectAuto && !reopening) {
                 var reOpendelay = reconnectFailures.length * reconnectAutoDelay;
@@ -213,12 +241,14 @@ confProto.openH2StreamForPush = function (pushUrl, proxyTransportUrl) {
         reopening = true;
         opened = true;
 
+        var transport = self.getTransport(proxyTransportUrl);
+
         var request = http2.raw.request({
             hostname: pushUri.hostname,
             port: pushUri.port,
             path: pushUri.path,
             transportUrl: proxyTransportUrl,
-            transport: self.getTransport(proxyTransportUrl),
+            transport: transport,
             agent: self.agent
         }, function (response) {
             reopening = false;
@@ -230,6 +260,7 @@ confProto.openH2StreamForPush = function (pushUrl, proxyTransportUrl) {
                 reconnectFailures.length = 0;
                 reopenH2StreamForPush(err, pushUri);
             });
+
             response.on('error', function (err) {
                 reopenH2StreamForPush(err, pushUri);
             });
@@ -237,6 +268,12 @@ confProto.openH2StreamForPush = function (pushUrl, proxyTransportUrl) {
             response.on('open', function () {
                 opened = true;
                 reconnectFailures.length = 0;
+            });
+
+            transport.on('close', function (err) {
+                opened = false;
+                reconnectFailures.length = 0;
+                reopenH2StreamForPush(err, pushUri);
             });
         });
 

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -231,7 +231,6 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
         var self = this,
             cache = configuration.cache,
-            transport = configuration.getTransport(proxyTransportUrl),
             requestUrl = getOrigin(destination.href) + destination.path,
             requestMethod = xhrInfo.get(self, 'method'),
             requestHeaders = xhrInfo.get(self, 'headers'),
@@ -295,6 +294,10 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 if (timeout) {
                     var otoDelegate = self.ontimeout;
                     self.ontimeout = function () {
+
+                        // Clear requestInfo revalidate state
+                        cache.validated(requestInfo);
+
                         // TODO abort
                         xhrInfo.put(self, 'timeoutOccured', true);
                         otoDelegate();
@@ -306,6 +309,8 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     timeoutTimer = setTimeout(self.ontimeout, timeout);
                     xhrInfo.put(self, 'timeoutTimer', timeoutTimer);
                 }
+
+                var transport = configuration.getTransport(proxyTransportUrl);
 
                 var request = http2.raw.request({
                     agent: configuration.agent,
@@ -367,12 +372,18 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
                 // TODO Why ?
                 request.on('error', function (/*e*/) {
+
+                    // Clear requestInfo revalidate state
+                    cache.validated(requestInfo);
+
                     // TODO, handle error
-                    // self._changeState('error');
+                    //self._changeState('error');
+
+                    self.__dispatchEvent(new ProgressEvent('error'));
                 });
 
                 // add to cache when receive pushRequest
-                request.on('push', function(respo){
+                request.on('push', function(respo) {
                     configuration.onPush(respo);
                 });
                 


### PR DESCRIPTION
Fix issue when RA disconnect and `XMLHttpRequest.configuration.cache._requestInfoRevalidating` state was invalid. Added revalidate on Xhr timeout and error, clearRevalidates on transport re-opening and close in case of missed disconnection.

To test:

1. Start stack
2. Start polling on test page (https://origin-server.example.com:8080)
3. Restart server (npm run leave && npm run init && npm run start)

# Current
Fail to clean stale-while-revalidate and fetch new response after re-connection.

# This PR
Should fix 
