### PR TITLE
Add require for collections/map in cache.js

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,7 +1,8 @@
 var Dict = require("collections/dict"),
     logger = require('./logger'),
     Promise = require("bluebird"),
-    keys = require('object-keys');
+    keys = require('object-keys'),
+    Map = require("collections/map");
 
 // https://github.com/roryf/parse-cache-control/blob/master/LICENSE
 /*


### PR DESCRIPTION
This should be pretty safe so the PR is only to ensure that you are aware of the issue. 


Cache uses 'instanceof Map' while caching request
headers, but did not require collections/map in the module.
This led to instanceof Map being a false negative in IE11
because it was checking the native Map against the collections
Map.