### PR TITLE
Add ./coverage to exclude property

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lib/"
   ],
   "exclude": [
+    "coverage",
     "example",
     "test",
     "integration-test",


### PR DESCRIPTION
Add`./coverage` to package.json#exclude so it is not included as a part of the npm package.