### PR TITLE
should fail to load inline configs without effect on future api usage

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -473,8 +473,7 @@ confProto.addConfig = function (config) {
     // Install transport
     if (config.hasOwnProperty('transport') && config.transport) {
 
-        // Validate transort
-
+        // Validate transport
         try {
             
             var transportUri = parseUrl(config.transport);

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -466,21 +466,31 @@ confProto.addConfig = function (config) {
     });
 
     // Merge config options
-    if (config.hasOwnProperty('options')) {
+    if (config.hasOwnProperty('options') && config.options) {
         that.setOptions(config.options);
     }
 
     // Install transport
-    if (config.hasOwnProperty('transport')) {
-        
-        // Add transport proxyfied urls 
-        if (config.hasOwnProperty('proxy')) {
-            that.addTransportUrls(config.proxy, config.transport);
-        }
+    if (config.hasOwnProperty('transport') && config.transport) {
 
-        // Connect transport to push url
-        if (config.hasOwnProperty('push')) {
-            that.openH2StreamForPush(parseUrl(config.push), config.transport);
+        // Validate transort
+
+        try {
+            
+            var transportUri = parseUrl(config.transport);
+            
+            // Add transport proxyfied urls 
+            if (config.hasOwnProperty('proxy')) {
+                that.addTransportUrls(config.proxy, transportUri);
+            }
+
+            // Connect transport to push url
+            if (config.hasOwnProperty('push') && config.push) {
+                that.openH2StreamForPush(parseUrl(config.push), transportUri);
+            }
+
+        } catch (err) {
+            that._log.error('XMLHttpRequest Http2-Cache configuration "transport" error', err);
         }
     }
 };

--- a/test/http2-proxy-test.js
+++ b/test/http2-proxy-test.js
@@ -170,6 +170,21 @@ describe('http2-proxy', function () {
         XMLHttpRequest.proxy(["http://localhost:7080/config", "http://localhost:7090/config"]);
     });
 
+    it('should fail to load inline configs without effect on future api usage', function (done) {
+        XMLHttpRequest.proxy(
+            [
+                {
+                    "push": "",
+                    "transport": "",
+                    // TODO why clientLogLevel on NodeJS Cause "Uncaught Error: Should only proxy '/path/proxy' not '/stream'"
+                    //"clientLogLevel": "info",
+                    "proxy": []
+                }
+            ]
+        );
+        done();
+    });
+
     it('should load inline configs', function (done) {
         XMLHttpRequest.proxy(
             [


### PR DESCRIPTION
Invalid config prevents page to load and put the shim in bad state, and prevent any native XHR to be performed.

Example:
```js
XMLHttpRequest.proxy(
    [
        {
            "push": "",
            "transport": "",
            "proxy": []
        }
    ]
);
```

<img width="540" alt="screen shot 2018-03-13 at 1 14 36 pm" src="https://user-images.githubusercontent.com/8635/37368412-78bda190-26c3-11e8-87ae-f42dbd8fa7cf.png">
