### PR TITLE
Bugs/post cached

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,13 @@
 Version history
 ===============
 
+### 0.2.15 (2018-12-06)
+* Fix possible cache hit on POST|PUT|DELETE (via #118)
+
 ### 0.2.14 (2018-12-06)
 * Fix bad merge on revalidate Cache
 
-### 0.2.13 (2018-07-18)
+### 0.2.13 (2018-12-05)
 
 * Cancel duplicate push promises streams #111 (via #113)
 * Force new authorization value through cache #112 (via #114).

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -105,7 +105,9 @@ var RequestInfo = function (method, href, headers) {
     var cacheControlHeader = getCacheControlHeaders(self);
     self.cacheDirectives = parseCacheControl(cacheControlHeader);
 
+    // TODO add header or body to hash or use sequense ?
     self.hash = self.method + '^' + self.href;
+
 };
 
 var privateCacheHashHeaders = ['authorization'];
@@ -194,6 +196,7 @@ function satisfiesRequest(requestInfo, candidate, candidateHash, revalidating) {
 }
 
 var CACHEABLE_BY_DEFAULT_STATUS_CODES = [200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501];
+
 function isCacheableResponse(response, cacheResponseDirectives) {
 
     if (CACHEABLE_BY_DEFAULT_STATUS_CODES.indexOf(response.statusCode) === -1) {
@@ -212,6 +215,44 @@ function isCacheableResponse(response, cacheResponseDirectives) {
     return false;
 }
 
+
+
+/*
+The corresponding RFC 2616 in section 9.5 (POST) allows the caching of the response to a 
+POST message, if you use the appropriate headers. Responses to this method are not cacheable, 
+unless the response includes appropriate Cache-Control or Expires header fields. However, the 303 (See Other) 
+response can be used to direct the user agent to retrieve a cacheable resource.
+
+Note that the same RFC states explicitly in section 13 (Caching in HTTP) that a cache must invalidate the 
+corresponding entity after a POST request.
+
+Some HTTP methods MUST cause a cache to invalidate an entity. This is either the entity referred to by the 
+Request-URI, or by the Location or Content-Location headers (if present). These methods are:
+
+  - PUT
+  - DELETE
+  - POST
+It's not clear to me how these specifications can allow meaningful caching.
+*/
+
+var CACHEABLE_BY_DEFAULT_METHODS = ['GET', 'HEAD', 'TRACE', 'OPTIONS', 'CONNECT'];
+
+function isCacheableRequest(requestInfo, requestCacheDirectives) {
+    if (CACHEABLE_BY_DEFAULT_METHODS.indexOf(requestInfo.method) === -1) {
+        return false;
+    }
+
+    if (
+        !requestCacheDirectives || 
+            // Bypass cache
+            (!requestCacheDirectives['no-cache'] && !requestCacheDirectives['no-store'])
+    ) {
+        return true;
+    }    
+
+    return false;
+}
+
 cp.match = function (requestInfo/*, options*/) {
 
     var self = this;
@@ -225,13 +266,9 @@ cp.match = function (requestInfo/*, options*/) {
             var requestCacheDirectives = requestInfo.cacheDirectives,
                 requestIsRevalidating = self.isRevalidating(requestInfo);
 
-            if (
-                // Cache by default 
-                // TODO why ?
-                requestCacheDirectives === null || 
-                    // Bypass cache
-                    (!requestCacheDirectives['no-cache'] && !requestCacheDirectives['no-store'])
-            ) {
+            // Only lookup in cache if request is cacheable
+            // TODO issue with PUSH does POST|PUT|DELETE can even be push ?
+            if (isCacheableRequest(requestInfo, requestCacheDirectives)) {
 
                 var candidate, candidateHash,
                     candidates = self._requestInfoToResponses.get(requestInfo.hash) || new Map(),
@@ -399,15 +436,20 @@ cp.put = function (requestInfo, response) {
                 reject(new Error("Not Cacheable response"));
             } else {
 
-                var candidates = self._requestInfoToResponses.get(requestInfo.hash) || new Map(),
-                    responseHash = requestInfo.getResponseHash(cacheResponseDirectives);
+                // Only store in cache if request is cacheable
+                var requestCacheDirectives = requestInfo.cacheDirectives;
+                if (isCacheableRequest(requestInfo, requestCacheDirectives) === true) {
 
-                if (self._debug) {
-                    self._log.debug("Adding cache entry to:" + requestInfo.hash + '/' + responseHash);
+                    var candidates = self._requestInfoToResponses.get(requestInfo.hash) || new Map(),
+                        responseHash = requestInfo.getResponseHash(cacheResponseDirectives);
+
+                    if (self._debug) {
+                        self._log.debug("Adding cache entry to:" + requestInfo.hash + '/' + responseHash);
+                    }
+
+                    candidates.set(responseHash, response);
+                    self._requestInfoToResponses.set(requestInfo.hash, candidates);
                 }
-
-                candidates.set(responseHash, response);
-                self._requestInfoToResponses.set(requestInfo.hash, candidates);
 
                 resolve();
             }
@@ -421,5 +463,6 @@ module.exports = {
     Cache: Cache,
     parseCacheControl: parseCacheControl,
     satisfiesRequest: satisfiesRequest,
+    isCacheableRequest: isCacheableRequest,
     isCacheableResponse: isCacheableResponse,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http2-cache",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Exposes http caching to the browser by adding functionality to XMLHttpRequest, and then running XMLHttpRequest over http2 over WebSockets",
   "main": "index.js",
   "browser": "dist/http2-cache.js",
@@ -31,7 +31,7 @@
     "test:jasmine": "npm run test:browser",
     "integration": "npm run test:browser",
     "build": "npm run build:browserify && npm run build:uglify",
-    "build:browserify": "browserify -r ./lib/http2-cache.js -s http2-cache > ./dist/http2-cache.js",
+    "build:browserify": "browserify -p [ browserify-banner --template '<%= pkg.name %> v<%= pkg.version %>' ] -r ./lib/http2-cache.js -s http2-cache > ./dist/http2-cache.js",
     "build:uglify": "uglifyjs dist/http2-cache.js -c > ./dist/http2-cache.min.js",
     "build:integration": "./node_modules/.bin/browserify -r ./test/http-cache-test.js -s tests > ./integration-test/http2-cache-tests.js"
   },
@@ -74,6 +74,7 @@
   "browserDependencies": {},
   "devDependencies": {
     "browserify": "^14.5.0",
+    "browserify-banner": "^1.0.12",
     "chai": "3.5.0",
     "concurrently": "^3.5.1",
     "http-server": "^0.10.0",

--- a/test/http-cache-test.js
+++ b/test/http-cache-test.js
@@ -13,6 +13,7 @@ var parseCacheControl = require('../lib/cache.js').parseCacheControl,
     RequestInfo = require('../lib/cache.js').RequestInfo,
     satisfiesRequest = require('../lib/cache.js').satisfiesRequest,
     isCacheableResponse = require('../lib/cache.js').isCacheableResponse,
+    isCacheableRequest = require('../lib/cache.js').isCacheableRequest,
     Cache = require('../lib/cache.js').Cache;
 
 describe('http-cache', function () {
@@ -27,6 +28,26 @@ describe('http-cache', function () {
     it('isCacheableResponse(response)', function () {
         assert.equal(isCacheableResponse({'headers': {'cache-control': 'max-age=30'}, 'statusCode': 200}), true);
         assert.equal(isCacheableResponse({'headers': {'cache-control': 'not-one-I-know'}, 'statusCode': 200}), false);
+    });
+
+    it('isCacheableRequest(request)', function () {
+        assert.equal(isCacheableRequest({'method': 'GET'}), true);
+        assert.equal(isCacheableRequest({'method': 'GET'}, {
+            'no-cache': true
+        }), false);
+        assert.equal(isCacheableRequest({'method': 'GET'}, {
+            'no-store': true
+        }), false);
+        assert.equal(isCacheableRequest({'method': 'GET'}, {
+            'no-store': true,
+            'no-cache': true
+        }), false);
+        assert.equal(isCacheableRequest({'method': 'HEAD'}), true);
+        assert.equal(isCacheableRequest({'method': 'CONNECT'}), true);
+        assert.equal(isCacheableRequest({'method': 'TRACE'}), true);
+        assert.equal(isCacheableRequest({'method': 'PUT'}), false);
+        assert.equal(isCacheableRequest({'method': 'POST'}), false);
+        assert.equal(isCacheableRequest({'method': 'DELETE'}), false);
     });
 
     // TODO better testing of max age and stale-while-revalidate
@@ -57,6 +78,66 @@ describe('http-cache', function () {
         cache.put(requestInfo, response1).then(function () {
             cache.match(requestInfo).then(function (r) {
                 assert.equal(r, response1);
+                done();
+            });
+        });
+    });
+
+    it('Cache returns no match for POST', function (done) {
+        var cache = new Cache();
+        var response1 = {
+            'href': 'https://example.com/', 
+            'headers': {
+                'cache-control': 
+                'max-age=30', 
+                'date': new Date()
+            }, 
+            'statusCode': 200
+        };
+        var requestInfo = new RequestInfo("POST", "https://example.com/", {});
+        cache.put(requestInfo, response1).then(function () {
+            cache.match(requestInfo).then(function (r) {
+                assert.equal(r, null);
+                done();
+            });
+        });
+    });
+
+    it('Cache returns no match for DELETE', function (done) {
+        var cache = new Cache();
+        var response1 = {
+            'href': 'https://example.com/', 
+            'headers': {
+                'cache-control': 
+                'max-age=30', 
+                'date': new Date()
+            }, 
+            'statusCode': 200
+        };
+        var requestInfo = new RequestInfo("DELETE", "https://example.com/", {});
+        cache.put(requestInfo, response1).then(function () {
+            cache.match(requestInfo).then(function (r) {
+                assert.equal(r, null);
+                done();
+            });
+        });
+    });
+
+    it('Cache returns no match for PUT', function (done) {
+        var cache = new Cache();
+        var response1 = {
+            'href': 'https://example.com/', 
+            'headers': {
+                'cache-control': 
+                'max-age=30', 
+                'date': new Date()
+            }, 
+            'statusCode': 200
+        };
+        var requestInfo = new RequestInfo("PUT", "https://example.com/", {});
+        cache.put(requestInfo, response1).then(function () {
+            cache.match(requestInfo).then(function (r) {
+                assert.equal(r, null);
                 done();
             });
         });


### PR DESCRIPTION
The previous Cache implementation did not follow RFC 2616 in section 9.5 that should not cache  response when method is POST|PUT|DELETE. (See detailed unit-test and spec reference in code).
Fix https://github.com/kaazing/kaazing.io/issues/994