### PR TITLE
Support trailers

### DIFF
--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -183,10 +183,10 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 this.__dispatchEvent(new ProgressEvent('progress'));
                 break;
             case XMLHttpRequest.DONE:
-                redefine(this, 'getResponseHeader', function (header) {
+                redefine(this, 'getResponseHeader', function(header) {
                     return options.response.headers[header.toLowerCase()];
                 });
-                redefine(this, 'getAllResponseHeaders', function () {
+                redefine(this, 'getAllResponseHeaders', function() {
                     var responseHeaders = options.response.headers;
                     return keys(responseHeaders).filter(function (responseHeader) {
                         return responseHeader !== 'toString';

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -34,7 +34,8 @@ var HTTP2_FORBIDDEN_HEADERS = ['accept-charset',
     'trailer',
     'transfer-encoding',
     'upgrade',
-    'via'];
+    'via'
+];
 
 var HTTP_METHODS = [
     'GET',
@@ -86,7 +87,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
     redefineProtoInfo(xhrProto, xhrInfo, "responseType", '');
     redefineProtoInfo(xhrProto, xhrInfo, "readyState", 0);
     redefineProtoInfo(xhrProto, xhrInfo, "timeout");
-    
+
     redefine(xhrProto, 'open', function (method, url, async, username, password) {
         // https://xhr.spec.whatwg.org/#the-open%28%29-method
         method = method.toUpperCase();
@@ -96,9 +97,9 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
         // parse so we know it is valid
         var parseurl = parseUrl(url);
 
-        if (async === undefined) {
+        if (async ===undefined) {
             async = true;
-        } else if (async === false) {
+        } else if (async ===false) {
             throw new SyntaxError("Synchronous is not supported");
         }
 
@@ -182,11 +183,24 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 this.__dispatchEvent(new ProgressEvent('progress'));
                 break;
             case XMLHttpRequest.DONE:
-                redefine(this, 'getResponseHeader', function(header) {
-                    return options.response.headers[header.toLowerCase()];
-                });
-                redefine(this, 'getAllResponseHeaders', function() {
+                redefine(this, 'getResponseHeader', function (header) {
                     var responseHeaders = options.response.headers;
+                    var trailers = options.response.trailers;
+                    for (var trailer in trailers) {
+                        if (trailers.hasOwnProperty(trailer)) {
+                            responseHeaders[trailer] = trailers[trailer];
+                        }
+                    }
+                    return responseHeaders[header.toLowerCase()];
+                });
+                redefine(this, 'getAllResponseHeaders', function () {
+                    var responseHeaders = options.response.headers;
+                    var trailers = options.response.trailers;
+                    for (var trailer in trailers) {
+                        if (trailers.hasOwnProperty(trailer)) {
+                            responseHeaders[trailer] = trailers[trailer];
+                        }
+                    }
                     return keys(responseHeaders).filter(function (responseHeader) {
                         return responseHeader !== 'toString';
                     }).map(function (responseHeader) {
@@ -205,10 +219,10 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             case XMLHttpRequest.OPENED:
                 break;
             default:
-            this.readyState = state;
-            if (this.readyState !== state) {
-                throw new Error('Unable to update readyState ' +  this.readyState + ' vs ' + state);
-            }
+                this.readyState = state;
+                if (this.readyState !== state) {
+                    throw new Error('Unable to update readyState ' + this.readyState + ' vs ' + state);
+                }
         }
         this.__dispatchEvent(new ProgressEvent('readystatechange'));
     });
@@ -221,7 +235,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             var responseType = xhrInfo.get(xhr, 'responseType') || '';
             return dataToType(response.data, responseType);
         });
-        
+
         defineGetter(xhr, 'responseText', function () {
 
             var responseType = xhrInfo.get(xhr, 'responseType') || '';
@@ -243,16 +257,16 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             requestMethod = xhrInfo.get(self, 'method'),
             requestHeaders = xhrInfo.get(self, 'headers'),
             requestInfo = new RequestInfo(requestMethod, requestUrl, requestHeaders);
-        
+
         // TODO reset response
         // TODO change getCache to readonly property
-        
+
         cache.match(requestInfo).then(function (cachedResponse) {
 
             // From http://www.w3.org/TR/2012/WD-XMLHttpRequest-20121206/
             // The user agent must allow author request headers to override automatic cache validation 
             // (e.g. if-none-match or if-modified-since), in which case 304 Not Modified responses must be passed through. [HTTP]
-            
+
             var cachedResponseHeader = cachedResponse !== null ? cachedResponse.headers : null,
                 revalidateResponse = cachedResponseHeader && cachedResponseHeader.hasOwnProperty('etag');
 
@@ -266,9 +280,15 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 defineXhrResponse(self, cachedResponse);
 
                 self.__dispatchEvent(new ProgressEvent('loadstart'));
-                self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {'response': cachedResponse});
-                self._changeState(XMLHttpRequest.LOADING, {'response': cachedResponse});
-                self._changeState(XMLHttpRequest.DONE, {'response': cachedResponse});
+                self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {
+                    'response': cachedResponse
+                });
+                self._changeState(XMLHttpRequest.LOADING, {
+                    'response': cachedResponse
+                });
+                self._changeState(XMLHttpRequest.DONE, {
+                    'response': cachedResponse
+                });
 
             } else {
 
@@ -279,9 +299,9 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     if (
                         // Require Etag
                         cachedResponseHeader.etag &&
-                            // Do not overide if provided
-                            requestHeaders.has('if-none-match') === false &&
-                                requestHeaders.has('if-match') === false
+                        // Do not overide if provided
+                        requestHeaders.has('if-none-match') === false &&
+                        requestHeaders.has('if-match') === false
                     ) {
                         // When used in combination with if-modified-since, it has precedence (if the server supports it).
                         requestHeaders.set('if-none-match', cachedResponseHeader.etag);
@@ -293,15 +313,15 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     // If the request has not been modified since, the response will be a 304 without any body;
                     if (
                         requestHeaders.has('if-none-match') === true &&
-                            // Do not overide if provided 
-                            requestHeaders.has('if-unmodified-since') === false && 
-                                requestHeaders.has('if-modified-since') === false 
+                        // Do not overide if provided 
+                        requestHeaders.has('if-unmodified-since') === false &&
+                        requestHeaders.has('if-modified-since') === false
                     ) {
                         // Unlike if-unmodified-since, if-modified-since can only be used with a GET or HEAD.
                         if (['GET', 'HEAD'].indexOf(requestMethod) !== -1) {
                             requestHeaders.set('if-modified-since', cachedResponseHeader.date);
                         } else {
-                            requestHeaders.set('if-unmodified-since', cachedResponseHeader.date);   
+                            requestHeaders.set('if-unmodified-since', cachedResponseHeader.date);
                         }
                     }
                 }
@@ -312,7 +332,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     // https://xhr.spec.whatwg.org/#the-send%28%29-method
                     if (
                         typeof HTMLElement !== 'undefined' &&
-                            body instanceof HTMLElement
+                        body instanceof HTMLElement
                     ) {
                         if (!requestHeaders.has('content-encoding')) {
                             requestHeaders.set('content-encoding', 'UTF-8');
@@ -332,7 +352,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     // only other option in spec is a String
                     // inject content-length TODO remove this as should not be required
                     requestHeaders.set('content-length', body.toString().length);
-                }   
+                }
 
 
                 var transport = configuration.getTransport(proxyTransportUrl);
@@ -362,50 +382,60 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     if (timeoutOccured) {
                         return;
                     }
-                    
+
                     clearTimeout(timeoutTimer);
 
                     // For 304 Not Modified responses that are a result of a user agent generated conditional request the 
                     // user agent must act as if the server gave a 200 OK response with the appropriate content. 
                     //console.log('newResponse', cachedResponseHeader, cachedResponse, newResponse.statusCode)
                     if (
-                        cachedResponse !== null && 
-                            revalidateResponse === true &&
-                                newResponse.statusCode === 304
+                        cachedResponse !== null &&
+                        revalidateResponse === true &&
+                        newResponse.statusCode === 304
                     ) {
 
                         // Export cached response
                         defineXhrResponse(self, cachedResponse);
 
-                        self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {'response': cachedResponse});
-                        self._changeState(XMLHttpRequest.LOADING, {'response': cachedResponse});
+                        self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {
+                            'response': cachedResponse
+                        });
+                        self._changeState(XMLHttpRequest.LOADING, {
+                            'response': cachedResponse
+                        });
 
                         if (newResponse.headers.hasOwnProperty('cache-control') === true) {
                             cachedResponse.headers['cache-control'] = newResponse.headers['cache-control'];
-                        } 
+                        }
 
                         if (newResponse.headers.hasOwnProperty('date') === true) {
                             cachedResponse.headers['date'] = newResponse.headers['date'];
                         }
 
-                        self._changeState(XMLHttpRequest.DONE, {'response': cachedResponse});
+                        self._changeState(XMLHttpRequest.DONE, {
+                            'response': cachedResponse
+                        });
 
                         // Clear requestInfo revalidate state
-                        cache.validated(requestInfo, request);  
+                        cache.validated(requestInfo, request);
 
                     } else {
 
                         // Export live response
                         defineXhrResponse(self, newResponse);
 
-                        self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {'response': newResponse});
+                        self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {
+                            'response': newResponse
+                        });
 
                         newResponse.on('data', function (data) {
                             newResponse.data = mergeTypedArrays(newResponse.data, data);
-                            self._changeState(XMLHttpRequest.LOADING, {'response': newResponse});
+                            self._changeState(XMLHttpRequest.LOADING, {
+                                'response': newResponse
+                            });
                         });
 
-                        newResponse.on('finish', function () {
+                        newResponse.on('end', function () {
 
                             if (configuration.debug) {
                                 configuration._log.debug("Got response for proxied XHR(" + destination.href + ")");
@@ -425,9 +455,9 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                             }).then(function () {
                                 self._changeState(XMLHttpRequest.DONE, {
                                     'response': newResponse
-                                }); 
+                                });
                                 // Clear requestInfo revalidate state
-                                cache.validated(requestInfo, request);  
+                                cache.validated(requestInfo, request);
                             });
                         });
                     }
@@ -464,7 +494,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 }
 
                 // Handle request error
-                request.on('error', function (/*e*/) {
+                request.on('error', function ( /*e*/ ) {
 
                     // Clear requestInfo revalidate state
                     cache.validated(requestInfo, request);
@@ -476,20 +506,20 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 });
 
                 // Handle transport error and fallback
-                transport.on('error', function (/*e*/) {
+                transport.on('error', function ( /*e*/ ) {
                     if (
                         self.readyState === XMLHttpRequest.UNSENT &&
-                            options.accelerationStrategy === 'connected'
+                        options.accelerationStrategy === 'connected'
                     ) {
-                        self.send();   
+                        self.send();
                     }
                 });
 
                 // Update cache when receive pushRequest
-                request.on('push', function(respo) {
+                request.on('push', function (respo) {
                     configuration.onPush(respo);
                 });
-                
+
                 request.end(body || null);
 
                 self.__dispatchEvent(new ProgressEvent('loadstart'));
@@ -498,7 +528,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
     });
 
     redefine(xhrProto, 'send', function (body) {
-        
+
         var self = this,
             url = xhrInfo.get(self, 'url'),
             headers = xhrInfo.get(self, 'headers');
@@ -529,9 +559,9 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
                 // Fix support for FormData if not null and object
                 if (body && typeof body === "object") {
-                    body = serializeXhrBody(headers, body);   
+                    body = serializeXhrBody(headers, body);
                 }
-                
+
                 self._sendViaHttp2(destination, body, proxyTransportUrl);
 
             } else {
@@ -553,13 +583,13 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
                 // Fix support for http2.js only if FormData is not defined and not null
                 if (body && typeof FormData === "undefined") {
-                    body = serializeXhrBody(headers, body);   
+                    body = serializeXhrBody(headers, body);
                 }
 
                 // Reset Headers
-                headers.forEach(function (value, key) {  
-                    self._setRequestHeader(key, value);                  
-                }, self);   
+                headers.forEach(function (value, key) {
+                    self._setRequestHeader(key, value);
+                }, self);
 
                 self._send(body);
             }

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -184,8 +184,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 break;
             case XMLHttpRequest.DONE:
                 redefine(this, 'getResponseHeader', function (header) {
-                    var responseHeaders = options.response.headers;
-                    return responseHeaders[header.toLowerCase()];
+                    return options.response.headers[header.toLowerCase()];
                 });
                 redefine(this, 'getAllResponseHeaders', function () {
                     var responseHeaders = options.response.headers;

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -34,7 +34,8 @@ var HTTP2_FORBIDDEN_HEADERS = ['accept-charset',
     'trailer',
     'transfer-encoding',
     'upgrade',
-    'via'];
+    'via'
+];
 
 var HTTP_METHODS = [
     'GET',
@@ -86,7 +87,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
     redefineProtoInfo(xhrProto, xhrInfo, "responseType", '');
     redefineProtoInfo(xhrProto, xhrInfo, "readyState", 0);
     redefineProtoInfo(xhrProto, xhrInfo, "timeout");
-    
+
     redefine(xhrProto, 'open', function (method, url, async, username, password) {
         // https://xhr.spec.whatwg.org/#the-open%28%29-method
         method = method.toUpperCase();
@@ -96,9 +97,9 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
         // parse so we know it is valid
         var parseurl = parseUrl(url);
 
-        if (async === undefined) {
+        if (async ===undefined) {
             async = true;
-        } else if (async === false) {
+        } else if (async ===false) {
             throw new SyntaxError("Synchronous is not supported");
         }
 
@@ -179,11 +180,24 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 this.__dispatchEvent(new ProgressEvent('progress'));
                 break;
             case XMLHttpRequest.DONE:
-                redefine(this, 'getResponseHeader', function(header) {
-                    return options.response.headers[header.toLowerCase()];
-                });
-                redefine(this, 'getAllResponseHeaders', function() {
+                redefine(this, 'getResponseHeader', function (header) {
                     var responseHeaders = options.response.headers;
+                    var trailers = options.response.trailes;
+                    for (var trailer in trailers) {
+                        if (trailers.hasOwnProperty(trailer)) {
+                            responseHeaders[header] = trailers[trailer];
+                        }
+                    }
+                    return responseHeaders[header.toLowerCase()];
+                });
+                redefine(this, 'getAllResponseHeaders', function () {
+                    var responseHeaders = options.response.headers;
+                    var trailers = options.response.trailes;
+                    for (var header in trailers) {
+                        if (trailers.hasOwnProperty(header)) {
+                            responseHeaders[header] = trailers[header];
+                        }
+                    }
                     return keys(responseHeaders).filter(function (responseHeader) {
                         return responseHeader !== 'toString';
                     }).map(function (responseHeader) {
@@ -202,10 +216,10 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             case XMLHttpRequest.OPENED:
                 break;
             default:
-            this.readyState = state;
-            if (this.readyState !== state) {
-                throw new Error('Unable to update readyState ' +  this.readyState + ' vs ' + state);
-            }
+                this.readyState = state;
+                if (this.readyState !== state) {
+                    throw new Error('Unable to update readyState ' + this.readyState + ' vs ' + state);
+                }
         }
         this.__dispatchEvent(new ProgressEvent('readystatechange'));
     });
@@ -218,7 +232,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             var responseType = xhrInfo.get(xhr, 'responseType') || '';
             return dataToType(response.data, responseType);
         });
-        
+
         defineGetter(xhr, 'responseText', function () {
 
             var responseType = xhrInfo.get(xhr, 'responseType') || '';
@@ -240,10 +254,10 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             requestMethod = xhrInfo.get(self, 'method'),
             requestHeaders = xhrInfo.get(self, 'headers'),
             requestInfo = new RequestInfo(requestMethod, requestUrl, requestHeaders);
-        
+
         // TODO reset response
         // TODO change getCache to readonly property
-        
+
         cache.match(requestInfo).then(function (response) {
             if (response) {
 
@@ -255,9 +269,15 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 defineXhrResponse(self, response);
 
                 self.__dispatchEvent(new ProgressEvent('loadstart'));
-                self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {'response': response});
-                self._changeState(XMLHttpRequest.LOADING, {'response': response});
-                self._changeState(XMLHttpRequest.DONE, {'response': response});
+                self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {
+                    'response': response
+                });
+                self._changeState(XMLHttpRequest.LOADING, {
+                    'response': response
+                });
+                self._changeState(XMLHttpRequest.DONE, {
+                    'response': response
+                });
 
             } else {
 
@@ -267,7 +287,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     // https://xhr.spec.whatwg.org/#the-send%28%29-method
                     if (
                         typeof HTMLElement !== 'undefined' &&
-                            body instanceof HTMLElement
+                        body instanceof HTMLElement
                     ) {
                         if (!requestHeaders.has('content-encoding')) {
                             requestHeaders.set('content-encoding', 'UTF-8');
@@ -341,20 +361,24 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     if (timeoutOccured) {
                         return;
                     }
-                    
+
                     clearTimeout(timeoutTimer);
 
                     // Export live response
                     defineXhrResponse(self, response);
 
-                    self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {'response': response});
+                    self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {
+                        'response': response
+                    });
 
                     response.on('data', function (data) {
                         response.data = mergeTypedArrays(response.data, data);
-                        self._changeState(XMLHttpRequest.LOADING, {'response': response});
+                        self._changeState(XMLHttpRequest.LOADING, {
+                            'response': response
+                        });
                     });
 
-                    response.on('finish', function () {
+                    response.on('end', function () {
 
                         if (configuration.debug) {
                             configuration._log.debug("Got response for proxied XHR(" + destination.href + ")");
@@ -363,20 +387,20 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                         cache.put(requestInfo, response).then(function () {
                             configuration._log.debug("Cache updated for proxied XHR(" + destination.href + ")");
                         }).catch(function (cacheError) {
-                            configuration._log.debug("Cache error for proxied XHR(" + destination.href + "):" + cacheError.message);                            
+                            configuration._log.debug("Cache error for proxied XHR(" + destination.href + "):" + cacheError.message);
                         }).then(function () {
                             self._changeState(XMLHttpRequest.DONE, {
                                 'response': response
                             });
 
                             // Clear requestInfo revalidate state
-                            cache.validated(requestInfo);  
+                            cache.validated(requestInfo);
                         });
                     });
                 });
 
                 // Handle request error
-                request.on('error', function (/*e*/) {
+                request.on('error', function ( /*e*/ ) {
 
                     // Clear requestInfo revalidate state
                     cache.validated(requestInfo);
@@ -388,20 +412,20 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 });
 
                 // Handle transport error and fallback
-                transport.on('error', function (/*e*/) {
+                transport.on('error', function ( /*e*/ ) {
                     if (
                         self.readyState === XMLHttpRequest.UNSENT &&
-                            options.accelerationStrategy === 'connected'
+                        options.accelerationStrategy === 'connected'
                     ) {
-                        self.send();   
+                        self.send();
                     }
                 });
 
                 // Update cache when receive pushRequest
-                request.on('push', function(respo) {
+                request.on('push', function (respo) {
                     configuration.onPush(respo);
                 });
-                
+
                 request.end(body || null);
 
                 // Set requestInfo revalidate state
@@ -414,7 +438,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
     });
 
     redefine(xhrProto, 'send', function (body) {
-        
+
         var self = this,
             url = xhrInfo.get(self, 'url'),
             headers = xhrInfo.get(self, 'headers');
@@ -445,9 +469,9 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
                 // Fix support for FormData if not null and object
                 if (body && typeof body === "object") {
-                    body = serializeXhrBody(headers, body);   
+                    body = serializeXhrBody(headers, body);
                 }
-                
+
                 self._sendViaHttp2(destination, body, proxyTransportUrl);
 
             } else {
@@ -469,13 +493,13 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
                 // Fix support for http2.js only if FormData is not defined and not null
                 if (body && typeof FormData === "undefined") {
-                    body = serializeXhrBody(headers, body);   
+                    body = serializeXhrBody(headers, body);
                 }
 
                 // Reset Headers
-                headers.forEach(function (value, key) {  
-                    self._setRequestHeader(key, value);                  
-                }, self);   
+                headers.forEach(function (value, key) {
+                    self._setRequestHeader(key, value);
+                }, self);
 
                 self._send(body);
             }

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -184,11 +184,11 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 break;
             case XMLHttpRequest.DONE:
                 redefine(this, 'getResponseHeader', function (header) {
-                    var responseHeaders = merge(options.response.headers, options.response.trailers);
+                    var responseHeaders = options.response.headers;
                     return responseHeaders[header.toLowerCase()];
                 });
                 redefine(this, 'getAllResponseHeaders', function () {
-                    var responseHeaders = merge(options.response.headers, options.response.trailers);
+                    var responseHeaders = options.response.headers;
                     return keys(responseHeaders).filter(function (responseHeader) {
                         return responseHeader !== 'toString';
                     }).map(function (responseHeader) {
@@ -407,7 +407,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                             self._changeState(XMLHttpRequest.LOADING, {'response': newResponse});
                         });
 
-                        newResponse.on('finish', function () {
+                        newResponse.on('end', function () {
 
                             if (configuration.debug) {
                                 configuration._log.debug("Got response for proxied XHR(" + destination.href + ")");
@@ -415,7 +415,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
                             // DEBUG:
                             //console.log('finish');
-
+                            newResponse.headers = merge(newResponse.headers, newResponse.trailers);
                             cache.put(requestInfo, newResponse).then(function (cachedResponse) {
                                 configuration._log.debug("Cache updated for proxied XHR(" + destination.href + ")");
                                 // TODO undefined why?

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -182,20 +182,20 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             case XMLHttpRequest.DONE:
                 redefine(this, 'getResponseHeader', function (header) {
                     var responseHeaders = options.response.headers;
-                    var trailers = options.response.trailes;
+                    var trailers = options.response.trailers;
                     for (var trailer in trailers) {
                         if (trailers.hasOwnProperty(trailer)) {
-                            responseHeaders[header] = trailers[trailer];
+                            responseHeaders[trailer] = trailers[trailer];
                         }
                     }
                     return responseHeaders[header.toLowerCase()];
                 });
                 redefine(this, 'getAllResponseHeaders', function () {
                     var responseHeaders = options.response.headers;
-                    var trailers = options.response.trailes;
-                    for (var header in trailers) {
-                        if (trailers.hasOwnProperty(header)) {
-                            responseHeaders[header] = trailers[header];
+                    var trailers = options.response.trailers;
+                    for (var trailer in trailers) {
+                        if (trailers.hasOwnProperty(trailer)) {
+                            responseHeaders[trailer] = trailers[trailer];
                         }
                     }
                     return keys(responseHeaders).filter(function (responseHeader) {

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -13,7 +13,8 @@ var http2 = require('http2.js'),
     mergeTypedArrays = require('./utils').mergeTypedArrays,
     InvalidStateError = require('./errors.js').InvalidStateError,
     XhrInfo = require('./xhr-info.js'),
-    Map = require("collections/map");
+    Map = require("collections/map"),
+    merge = require('lodash.merge');
 
 var HTTP2_FORBIDDEN_HEADERS = ['accept-charset',
     'accept-encoding',
@@ -182,11 +183,12 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 this.__dispatchEvent(new ProgressEvent('progress'));
                 break;
             case XMLHttpRequest.DONE:
-                redefine(this, 'getResponseHeader', function(header) {
-                    return options.response.headers[header.toLowerCase()];
+                redefine(this, 'getResponseHeader', function (header) {
+                    var responseHeaders = merge(options.response.headers, options.response.trailers);
+                    return responseHeaders[header.toLowerCase()];
                 });
-                redefine(this, 'getAllResponseHeaders', function() {
-                    var responseHeaders = options.response.headers;
+                redefine(this, 'getAllResponseHeaders', function () {
+                    var responseHeaders = merge(options.response.headers, options.response.trailers);
                     return keys(responseHeaders).filter(function (responseHeader) {
                         return responseHeader !== 'toString';
                     }).map(function (responseHeader) {

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -34,8 +34,7 @@ var HTTP2_FORBIDDEN_HEADERS = ['accept-charset',
     'trailer',
     'transfer-encoding',
     'upgrade',
-    'via'
-];
+    'via'];
 
 var HTTP_METHODS = [
     'GET',
@@ -87,7 +86,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
     redefineProtoInfo(xhrProto, xhrInfo, "responseType", '');
     redefineProtoInfo(xhrProto, xhrInfo, "readyState", 0);
     redefineProtoInfo(xhrProto, xhrInfo, "timeout");
-
+    
     redefine(xhrProto, 'open', function (method, url, async, username, password) {
         // https://xhr.spec.whatwg.org/#the-open%28%29-method
         method = method.toUpperCase();
@@ -97,9 +96,9 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
         // parse so we know it is valid
         var parseurl = parseUrl(url);
 
-        if (async ===undefined) {
+        if (async === undefined) {
             async = true;
-        } else if (async ===false) {
+        } else if (async === false) {
             throw new SyntaxError("Synchronous is not supported");
         }
 
@@ -156,6 +155,18 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
         headers.set(lcname, value);
     });
 
+    function defineXhrStatusCode(xhr, statusCode) {
+        defineGetter(xhr, 'status', function () {
+            return statusCode;
+        });
+        var statusMessage = http2.STATUS_CODES[statusCode];
+        if (statusMessage) {
+            xhr.statusText = statusMessage;
+        } else {
+            configuration._log.warn('Unknown STATUS CODE: ' + statusCode);
+        }
+    }
+
     definePrivate(xhrProto, '_changeState', function (state, options) {
         var self = this;
 
@@ -165,39 +176,17 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             case XMLHttpRequest.OPENED:
                 break;
             case XMLHttpRequest.HEADERS_RECEIVED:
-                var statusCode = options.response.statusCode;
-                defineGetter(this, 'status', function () {
-                    return statusCode;
-                });
-                var statusMessage = http2.STATUS_CODES[statusCode];
-                if (statusMessage) {
-                    this.statusText = statusMessage;
-                } else {
-                    configuration._log.warn('Unknown STATUS CODE: ' + statusCode);
-                }
+                defineXhrStatusCode(self, options.response.statusCode);
                 break;
             case XMLHttpRequest.LOADING:
                 this.__dispatchEvent(new ProgressEvent('progress'));
                 break;
             case XMLHttpRequest.DONE:
-                redefine(this, 'getResponseHeader', function (header) {
-                    var responseHeaders = options.response.headers;
-                    var trailers = options.response.trailers;
-                    for (var trailer in trailers) {
-                        if (trailers.hasOwnProperty(trailer)) {
-                            responseHeaders[trailer] = trailers[trailer];
-                        }
-                    }
-                    return responseHeaders[header.toLowerCase()];
+                redefine(this, 'getResponseHeader', function(header) {
+                    return options.response.headers[header.toLowerCase()];
                 });
-                redefine(this, 'getAllResponseHeaders', function () {
+                redefine(this, 'getAllResponseHeaders', function() {
                     var responseHeaders = options.response.headers;
-                    var trailers = options.response.trailers;
-                    for (var trailer in trailers) {
-                        if (trailers.hasOwnProperty(trailer)) {
-                            responseHeaders[trailer] = trailers[trailer];
-                        }
-                    }
                     return keys(responseHeaders).filter(function (responseHeader) {
                         return responseHeader !== 'toString';
                     }).map(function (responseHeader) {
@@ -216,10 +205,10 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             case XMLHttpRequest.OPENED:
                 break;
             default:
-                this.readyState = state;
-                if (this.readyState !== state) {
-                    throw new Error('Unable to update readyState ' + this.readyState + ' vs ' + state);
-                }
+            this.readyState = state;
+            if (this.readyState !== state) {
+                throw new Error('Unable to update readyState ' +  this.readyState + ' vs ' + state);
+            }
         }
         this.__dispatchEvent(new ProgressEvent('readystatechange'));
     });
@@ -232,7 +221,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             var responseType = xhrInfo.get(xhr, 'responseType') || '';
             return dataToType(response.data, responseType);
         });
-
+        
         defineGetter(xhr, 'responseText', function () {
 
             var responseType = xhrInfo.get(xhr, 'responseType') || '';
@@ -254,32 +243,68 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             requestMethod = xhrInfo.get(self, 'method'),
             requestHeaders = xhrInfo.get(self, 'headers'),
             requestInfo = new RequestInfo(requestMethod, requestUrl, requestHeaders);
-
+        
         // TODO reset response
         // TODO change getCache to readonly property
+        
+        cache.match(requestInfo).then(function (cachedResponse) {
 
-        cache.match(requestInfo).then(function (response) {
-            if (response) {
+            // From http://www.w3.org/TR/2012/WD-XMLHttpRequest-20121206/
+            // The user agent must allow author request headers to override automatic cache validation 
+            // (e.g. if-none-match or if-modified-since), in which case 304 Not Modified responses must be passed through. [HTTP]
+            
+            var cachedResponseHeader = cachedResponse !== null ? cachedResponse.headers : null,
+                revalidateResponse = cachedResponseHeader && cachedResponseHeader.hasOwnProperty('etag');
+
+            if (cachedResponse !== null && revalidateResponse === false) {
 
                 if (configuration.debug) {
                     configuration._log.debug("Using cache result for XHR(" + destination.href + ")");
                 }
 
                 // Export cached response
-                defineXhrResponse(self, response);
+                defineXhrResponse(self, cachedResponse);
 
                 self.__dispatchEvent(new ProgressEvent('loadstart'));
-                self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {
-                    'response': response
-                });
-                self._changeState(XMLHttpRequest.LOADING, {
-                    'response': response
-                });
-                self._changeState(XMLHttpRequest.DONE, {
-                    'response': response
-                });
+                self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {'response': cachedResponse});
+                self._changeState(XMLHttpRequest.LOADING, {'response': cachedResponse});
+                self._changeState(XMLHttpRequest.DONE, {'response': cachedResponse});
 
             } else {
+
+                // Revalidate if had cachedResponse and require so
+                if (cachedResponse !== null && revalidateResponse === true) {
+
+                    // Inject ETag of not present or has already 'If-Match'
+                    if (
+                        // Require Etag
+                        cachedResponseHeader.etag &&
+                            // Do not overide if provided
+                            requestHeaders.has('if-none-match') === false &&
+                                requestHeaders.has('if-match') === false
+                    ) {
+                        // When used in combination with if-modified-since, it has precedence (if the server supports it).
+                        requestHeaders.set('if-none-match', cachedResponseHeader.etag);
+                    }
+
+                    // Inject if-modified-since
+                    // The if-modified-since request HTTP header makes the request conditional: the server will send back the 
+                    // requested resource, with a 200 status, only if it has been last modified after the given date. 
+                    // If the request has not been modified since, the response will be a 304 without any body;
+                    if (
+                        requestHeaders.has('if-none-match') === true &&
+                            // Do not overide if provided 
+                            requestHeaders.has('if-unmodified-since') === false && 
+                                requestHeaders.has('if-modified-since') === false 
+                    ) {
+                        // Unlike if-unmodified-since, if-modified-since can only be used with a GET or HEAD.
+                        if (['GET', 'HEAD'].indexOf(requestMethod) !== -1) {
+                            requestHeaders.set('if-modified-since', cachedResponseHeader.date);
+                        } else {
+                            requestHeaders.set('if-unmodified-since', cachedResponseHeader.date);   
+                        }
+                    }
+                }
 
                 // Need to make the request your self
                 if (body) {
@@ -287,7 +312,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     // https://xhr.spec.whatwg.org/#the-send%28%29-method
                     if (
                         typeof HTMLElement !== 'undefined' &&
-                        body instanceof HTMLElement
+                            body instanceof HTMLElement
                     ) {
                         if (!requestHeaders.has('content-encoding')) {
                             requestHeaders.set('content-encoding', 'UTF-8');
@@ -307,35 +332,11 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     // only other option in spec is a String
                     // inject content-length TODO remove this as should not be required
                     requestHeaders.set('content-length', body.toString().length);
-                }
+                }   
 
-                // TODO use isRevalidating and store request in cache.revalidate 
-                // cache.isRevalidating(requestInfo)
-
-                // Naive Timeout implementation
-                var timeout = xhrInfo.get(self, 'timeout'),
-                    timeoutTimer = xhrInfo.get(self, 'timeoutTimer');
-
-                if (timeout) {
-                    var otoDelegate = self.ontimeout;
-                    self.ontimeout = function () {
-
-                        // Clear requestInfo revalidate state
-                        cache.validated(requestInfo);
-
-                        // TODO abort
-                        xhrInfo.put(self, 'timeoutOccured', true);
-                        otoDelegate();
-                    };
-
-                    clearTimeout(timeoutTimer);
-                    xhrInfo.put(self, 'timeoutOccured', false);
-
-                    timeoutTimer = setTimeout(self.ontimeout, timeout);
-                    xhrInfo.put(self, 'timeoutTimer', timeoutTimer);
-                }
 
                 var transport = configuration.getTransport(proxyTransportUrl);
+
 
                 var request = http2.raw.request({
                     agent: configuration.agent,
@@ -352,7 +353,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     transportUrl: proxyTransportUrl
                     // TODO timeout if syncronization set
                     // timeout: self.__timeout
-                }, function (response) {
+                }, function (newResponse) {
 
                     var timeoutOccured = xhrInfo.get(self, 'timeoutOccured'),
                         timeoutTimer = xhrInfo.get(self, 'timeoutTimer');
@@ -361,49 +362,112 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     if (timeoutOccured) {
                         return;
                     }
-
+                    
                     clearTimeout(timeoutTimer);
 
-                    // Export live response
-                    defineXhrResponse(self, response);
+                    // For 304 Not Modified responses that are a result of a user agent generated conditional request the 
+                    // user agent must act as if the server gave a 200 OK response with the appropriate content. 
+                    //console.log('newResponse', cachedResponseHeader, cachedResponse, newResponse.statusCode)
+                    if (
+                        cachedResponse !== null && 
+                            revalidateResponse === true &&
+                                newResponse.statusCode === 304
+                    ) {
 
-                    self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {
-                        'response': response
-                    });
+                        // Export cached response
+                        defineXhrResponse(self, cachedResponse);
 
-                    response.on('data', function (data) {
-                        response.data = mergeTypedArrays(response.data, data);
-                        self._changeState(XMLHttpRequest.LOADING, {
-                            'response': response
-                        });
-                    });
+                        self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {'response': cachedResponse});
+                        self._changeState(XMLHttpRequest.LOADING, {'response': cachedResponse});
 
-                    response.on('end', function () {
+                        if (newResponse.headers.hasOwnProperty('cache-control') === true) {
+                            cachedResponse.headers['cache-control'] = newResponse.headers['cache-control'];
+                        } 
 
-                        if (configuration.debug) {
-                            configuration._log.debug("Got response for proxied XHR(" + destination.href + ")");
+                        if (newResponse.headers.hasOwnProperty('date') === true) {
+                            cachedResponse.headers['date'] = newResponse.headers['date'];
                         }
 
-                        cache.put(requestInfo, response).then(function () {
-                            configuration._log.debug("Cache updated for proxied XHR(" + destination.href + ")");
-                        }).catch(function (cacheError) {
-                            configuration._log.debug("Cache error for proxied XHR(" + destination.href + "):" + cacheError.message);
-                        }).then(function () {
-                            self._changeState(XMLHttpRequest.DONE, {
-                                'response': response
-                            });
+                        self._changeState(XMLHttpRequest.DONE, {'response': cachedResponse});
 
-                            // Clear requestInfo revalidate state
-                            cache.validated(requestInfo);
+                        // Clear requestInfo revalidate state
+                        cache.validated(requestInfo, request);  
+
+                    } else {
+
+                        // Export live response
+                        defineXhrResponse(self, newResponse);
+
+                        self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {'response': newResponse});
+
+                        newResponse.on('data', function (data) {
+                            newResponse.data = mergeTypedArrays(newResponse.data, data);
+                            self._changeState(XMLHttpRequest.LOADING, {'response': newResponse});
                         });
-                    });
+
+                        newResponse.on('finish', function () {
+
+                            if (configuration.debug) {
+                                configuration._log.debug("Got response for proxied XHR(" + destination.href + ")");
+                            }
+
+                            // DEBUG:
+                            //console.log('finish');
+
+                            cache.put(requestInfo, newResponse).then(function (cachedResponse) {
+                                configuration._log.debug("Cache updated for proxied XHR(" + destination.href + ")");
+                                // TODO undefined why?
+                                //console.log('cache', cachedResponse);
+                            }).catch(function (cacheError) {
+                                configuration._log.debug("Cache error for proxied XHR(" + destination.href + "):" + cacheError.message);
+                                // DEBUG:
+                                //console.log(cacheError, cacheError.stack);
+                            }).then(function () {
+                                self._changeState(XMLHttpRequest.DONE, {
+                                    'response': newResponse
+                                }); 
+                                // Clear requestInfo revalidate state
+                                cache.validated(requestInfo, request);  
+                            });
+                        });
+                    }
                 });
 
+                // Set requestInfo revalidate state
+                // TODO pass request for future dedup pending requestInfo
+                cache.revalidate(requestInfo, request);
+
+                // TODO use isRevalidating and store request in cache.revalidate 
+                // cache.isRevalidating(requestInfo, request)
+
+                // Naive Timeout implementation
+                var timeout = xhrInfo.get(self, 'timeout'),
+                    timeoutTimer = xhrInfo.get(self, 'timeoutTimer');
+
+                if (timeout) {
+                    var otoDelegate = self.ontimeout;
+                    self.ontimeout = function () {
+
+                        // Clear requestInfo revalidate state
+                        cache.validated(requestInfo, request);
+
+                        // TODO abort
+                        xhrInfo.put(self, 'timeoutOccured', true);
+                        otoDelegate();
+                    };
+
+                    clearTimeout(timeoutTimer);
+                    xhrInfo.put(self, 'timeoutOccured', false);
+
+                    timeoutTimer = setTimeout(self.ontimeout, timeout);
+                    xhrInfo.put(self, 'timeoutTimer', timeoutTimer);
+                }
+
                 // Handle request error
-                request.on('error', function ( /*e*/ ) {
+                request.on('error', function (/*e*/) {
 
                     // Clear requestInfo revalidate state
-                    cache.validated(requestInfo);
+                    cache.validated(requestInfo, request);
 
                     // Only propagate error if accelerationStrategy is always
                     if (options.accelerationStrategy === 'always') {
@@ -412,25 +476,21 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 });
 
                 // Handle transport error and fallback
-                transport.on('error', function ( /*e*/ ) {
+                transport.on('error', function (/*e*/) {
                     if (
                         self.readyState === XMLHttpRequest.UNSENT &&
-                        options.accelerationStrategy === 'connected'
+                            options.accelerationStrategy === 'connected'
                     ) {
-                        self.send();
+                        self.send();   
                     }
                 });
 
                 // Update cache when receive pushRequest
-                request.on('push', function (respo) {
+                request.on('push', function(respo) {
                     configuration.onPush(respo);
                 });
-
+                
                 request.end(body || null);
-
-                // Set requestInfo revalidate state
-                // TODO pass request for future dedup pending requestInfo
-                cache.revalidate(requestInfo);
 
                 self.__dispatchEvent(new ProgressEvent('loadstart'));
             }
@@ -438,7 +498,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
     });
 
     redefine(xhrProto, 'send', function (body) {
-
+        
         var self = this,
             url = xhrInfo.get(self, 'url'),
             headers = xhrInfo.get(self, 'headers');
@@ -469,9 +529,9 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
                 // Fix support for FormData if not null and object
                 if (body && typeof body === "object") {
-                    body = serializeXhrBody(headers, body);
+                    body = serializeXhrBody(headers, body);   
                 }
-
+                
                 self._sendViaHttp2(destination, body, proxyTransportUrl);
 
             } else {
@@ -493,13 +553,13 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
                 // Fix support for http2.js only if FormData is not defined and not null
                 if (body && typeof FormData === "undefined") {
-                    body = serializeXhrBody(headers, body);
+                    body = serializeXhrBody(headers, body);   
                 }
 
                 // Reset Headers
-                headers.forEach(function (value, key) {
-                    self._setRequestHeader(key, value);
-                }, self);
+                headers.forEach(function (value, key) {  
+                    self._setRequestHeader(key, value);                  
+                }, self);   
 
                 self._send(body);
             }

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -34,8 +34,7 @@ var HTTP2_FORBIDDEN_HEADERS = ['accept-charset',
     'trailer',
     'transfer-encoding',
     'upgrade',
-    'via'
-];
+    'via'];
 
 var HTTP_METHODS = [
     'GET',
@@ -87,7 +86,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
     redefineProtoInfo(xhrProto, xhrInfo, "responseType", '');
     redefineProtoInfo(xhrProto, xhrInfo, "readyState", 0);
     redefineProtoInfo(xhrProto, xhrInfo, "timeout");
-
+    
     redefine(xhrProto, 'open', function (method, url, async, username, password) {
         // https://xhr.spec.whatwg.org/#the-open%28%29-method
         method = method.toUpperCase();
@@ -97,9 +96,9 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
         // parse so we know it is valid
         var parseurl = parseUrl(url);
 
-        if (async ===undefined) {
+        if (async === undefined) {
             async = true;
-        } else if (async ===false) {
+        } else if (async === false) {
             throw new SyntaxError("Synchronous is not supported");
         }
 
@@ -183,24 +182,11 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 this.__dispatchEvent(new ProgressEvent('progress'));
                 break;
             case XMLHttpRequest.DONE:
-                redefine(this, 'getResponseHeader', function (header) {
-                    var responseHeaders = options.response.headers;
-                    var trailers = options.response.trailers;
-                    for (var trailer in trailers) {
-                        if (trailers.hasOwnProperty(trailer)) {
-                            responseHeaders[trailer] = trailers[trailer];
-                        }
-                    }
-                    return responseHeaders[header.toLowerCase()];
+                redefine(this, 'getResponseHeader', function(header) {
+                    return options.response.headers[header.toLowerCase()];
                 });
-                redefine(this, 'getAllResponseHeaders', function () {
+                redefine(this, 'getAllResponseHeaders', function() {
                     var responseHeaders = options.response.headers;
-                    var trailers = options.response.trailers;
-                    for (var trailer in trailers) {
-                        if (trailers.hasOwnProperty(trailer)) {
-                            responseHeaders[trailer] = trailers[trailer];
-                        }
-                    }
                     return keys(responseHeaders).filter(function (responseHeader) {
                         return responseHeader !== 'toString';
                     }).map(function (responseHeader) {
@@ -219,10 +205,10 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             case XMLHttpRequest.OPENED:
                 break;
             default:
-                this.readyState = state;
-                if (this.readyState !== state) {
-                    throw new Error('Unable to update readyState ' + this.readyState + ' vs ' + state);
-                }
+            this.readyState = state;
+            if (this.readyState !== state) {
+                throw new Error('Unable to update readyState ' +  this.readyState + ' vs ' + state);
+            }
         }
         this.__dispatchEvent(new ProgressEvent('readystatechange'));
     });
@@ -235,7 +221,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             var responseType = xhrInfo.get(xhr, 'responseType') || '';
             return dataToType(response.data, responseType);
         });
-
+        
         defineGetter(xhr, 'responseText', function () {
 
             var responseType = xhrInfo.get(xhr, 'responseType') || '';
@@ -257,16 +243,16 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             requestMethod = xhrInfo.get(self, 'method'),
             requestHeaders = xhrInfo.get(self, 'headers'),
             requestInfo = new RequestInfo(requestMethod, requestUrl, requestHeaders);
-
+        
         // TODO reset response
         // TODO change getCache to readonly property
-
+        
         cache.match(requestInfo).then(function (cachedResponse) {
 
             // From http://www.w3.org/TR/2012/WD-XMLHttpRequest-20121206/
             // The user agent must allow author request headers to override automatic cache validation 
             // (e.g. if-none-match or if-modified-since), in which case 304 Not Modified responses must be passed through. [HTTP]
-
+            
             var cachedResponseHeader = cachedResponse !== null ? cachedResponse.headers : null,
                 revalidateResponse = cachedResponseHeader && cachedResponseHeader.hasOwnProperty('etag');
 
@@ -280,15 +266,9 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 defineXhrResponse(self, cachedResponse);
 
                 self.__dispatchEvent(new ProgressEvent('loadstart'));
-                self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {
-                    'response': cachedResponse
-                });
-                self._changeState(XMLHttpRequest.LOADING, {
-                    'response': cachedResponse
-                });
-                self._changeState(XMLHttpRequest.DONE, {
-                    'response': cachedResponse
-                });
+                self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {'response': cachedResponse});
+                self._changeState(XMLHttpRequest.LOADING, {'response': cachedResponse});
+                self._changeState(XMLHttpRequest.DONE, {'response': cachedResponse});
 
             } else {
 
@@ -299,9 +279,9 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     if (
                         // Require Etag
                         cachedResponseHeader.etag &&
-                        // Do not overide if provided
-                        requestHeaders.has('if-none-match') === false &&
-                        requestHeaders.has('if-match') === false
+                            // Do not overide if provided
+                            requestHeaders.has('if-none-match') === false &&
+                                requestHeaders.has('if-match') === false
                     ) {
                         // When used in combination with if-modified-since, it has precedence (if the server supports it).
                         requestHeaders.set('if-none-match', cachedResponseHeader.etag);
@@ -313,15 +293,15 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     // If the request has not been modified since, the response will be a 304 without any body;
                     if (
                         requestHeaders.has('if-none-match') === true &&
-                        // Do not overide if provided 
-                        requestHeaders.has('if-unmodified-since') === false &&
-                        requestHeaders.has('if-modified-since') === false
+                            // Do not overide if provided 
+                            requestHeaders.has('if-unmodified-since') === false && 
+                                requestHeaders.has('if-modified-since') === false 
                     ) {
                         // Unlike if-unmodified-since, if-modified-since can only be used with a GET or HEAD.
                         if (['GET', 'HEAD'].indexOf(requestMethod) !== -1) {
                             requestHeaders.set('if-modified-since', cachedResponseHeader.date);
                         } else {
-                            requestHeaders.set('if-unmodified-since', cachedResponseHeader.date);
+                            requestHeaders.set('if-unmodified-since', cachedResponseHeader.date);   
                         }
                     }
                 }
@@ -332,7 +312,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     // https://xhr.spec.whatwg.org/#the-send%28%29-method
                     if (
                         typeof HTMLElement !== 'undefined' &&
-                        body instanceof HTMLElement
+                            body instanceof HTMLElement
                     ) {
                         if (!requestHeaders.has('content-encoding')) {
                             requestHeaders.set('content-encoding', 'UTF-8');
@@ -352,7 +332,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     // only other option in spec is a String
                     // inject content-length TODO remove this as should not be required
                     requestHeaders.set('content-length', body.toString().length);
-                }
+                }   
 
 
                 var transport = configuration.getTransport(proxyTransportUrl);
@@ -382,60 +362,50 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                     if (timeoutOccured) {
                         return;
                     }
-
+                    
                     clearTimeout(timeoutTimer);
 
                     // For 304 Not Modified responses that are a result of a user agent generated conditional request the 
                     // user agent must act as if the server gave a 200 OK response with the appropriate content. 
                     //console.log('newResponse', cachedResponseHeader, cachedResponse, newResponse.statusCode)
                     if (
-                        cachedResponse !== null &&
-                        revalidateResponse === true &&
-                        newResponse.statusCode === 304
+                        cachedResponse !== null && 
+                            revalidateResponse === true &&
+                                newResponse.statusCode === 304
                     ) {
 
                         // Export cached response
                         defineXhrResponse(self, cachedResponse);
 
-                        self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {
-                            'response': cachedResponse
-                        });
-                        self._changeState(XMLHttpRequest.LOADING, {
-                            'response': cachedResponse
-                        });
+                        self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {'response': cachedResponse});
+                        self._changeState(XMLHttpRequest.LOADING, {'response': cachedResponse});
 
                         if (newResponse.headers.hasOwnProperty('cache-control') === true) {
                             cachedResponse.headers['cache-control'] = newResponse.headers['cache-control'];
-                        }
+                        } 
 
                         if (newResponse.headers.hasOwnProperty('date') === true) {
                             cachedResponse.headers['date'] = newResponse.headers['date'];
                         }
 
-                        self._changeState(XMLHttpRequest.DONE, {
-                            'response': cachedResponse
-                        });
+                        self._changeState(XMLHttpRequest.DONE, {'response': cachedResponse});
 
                         // Clear requestInfo revalidate state
-                        cache.validated(requestInfo, request);
+                        cache.validated(requestInfo, request);  
 
                     } else {
 
                         // Export live response
                         defineXhrResponse(self, newResponse);
 
-                        self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {
-                            'response': newResponse
-                        });
+                        self._changeState(XMLHttpRequest.HEADERS_RECEIVED, {'response': newResponse});
 
                         newResponse.on('data', function (data) {
                             newResponse.data = mergeTypedArrays(newResponse.data, data);
-                            self._changeState(XMLHttpRequest.LOADING, {
-                                'response': newResponse
-                            });
+                            self._changeState(XMLHttpRequest.LOADING, {'response': newResponse});
                         });
 
-                        newResponse.on('end', function () {
+                        newResponse.on('finish', function () {
 
                             if (configuration.debug) {
                                 configuration._log.debug("Got response for proxied XHR(" + destination.href + ")");
@@ -455,9 +425,9 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                             }).then(function () {
                                 self._changeState(XMLHttpRequest.DONE, {
                                     'response': newResponse
-                                });
+                                }); 
                                 // Clear requestInfo revalidate state
-                                cache.validated(requestInfo, request);
+                                cache.validated(requestInfo, request);  
                             });
                         });
                     }
@@ -494,7 +464,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 }
 
                 // Handle request error
-                request.on('error', function ( /*e*/ ) {
+                request.on('error', function (/*e*/) {
 
                     // Clear requestInfo revalidate state
                     cache.validated(requestInfo, request);
@@ -506,20 +476,20 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 });
 
                 // Handle transport error and fallback
-                transport.on('error', function ( /*e*/ ) {
+                transport.on('error', function (/*e*/) {
                     if (
                         self.readyState === XMLHttpRequest.UNSENT &&
-                        options.accelerationStrategy === 'connected'
+                            options.accelerationStrategy === 'connected'
                     ) {
-                        self.send();
+                        self.send();   
                     }
                 });
 
                 // Update cache when receive pushRequest
-                request.on('push', function (respo) {
+                request.on('push', function(respo) {
                     configuration.onPush(respo);
                 });
-
+                
                 request.end(body || null);
 
                 self.__dispatchEvent(new ProgressEvent('loadstart'));
@@ -528,7 +498,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
     });
 
     redefine(xhrProto, 'send', function (body) {
-
+        
         var self = this,
             url = xhrInfo.get(self, 'url'),
             headers = xhrInfo.get(self, 'headers');
@@ -559,9 +529,9 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
                 // Fix support for FormData if not null and object
                 if (body && typeof body === "object") {
-                    body = serializeXhrBody(headers, body);
+                    body = serializeXhrBody(headers, body);   
                 }
-
+                
                 self._sendViaHttp2(destination, body, proxyTransportUrl);
 
             } else {
@@ -583,13 +553,13 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
                 // Fix support for http2.js only if FormData is not defined and not null
                 if (body && typeof FormData === "undefined") {
-                    body = serializeXhrBody(headers, body);
+                    body = serializeXhrBody(headers, body);   
                 }
 
                 // Reset Headers
-                headers.forEach(function (value, key) {
-                    self._setRequestHeader(key, value);
-                }, self);
+                headers.forEach(function (value, key) {  
+                    self._setRequestHeader(key, value);                  
+                }, self);   
 
                 self._send(body);
             }

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -415,7 +415,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
                             // DEBUG:
                             //console.log('finish');
-                            newResponse.headers = merge(newResponse.headers, newResponse.trailers);
+                            merge(newResponse.headers, newResponse.trailers);
                             cache.put(requestInfo, newResponse).then(function (cachedResponse) {
                                 configuration._log.debug("Cache updated for proxied XHR(" + destination.href + ")");
                                 // TODO undefined why?

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "collections": "^5.1.1",
     "http2.js": "^4.0.6",
+    "lodash.merge": "^4.6.1",
     "object-assign": "^4.1.1",
     "object-keys": "^1.0.11",
     "string.fromcodepoint": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "karma-firefox-launcher": "^1.1.0",
     "karma-mocha": "^1.3.0",
     "karma-sinon-chai": "^1.3.3",
-    "mocha": "^4.0.1",
+    "mocha": "^4.1.0",
     "npm-k3po": "https://github.com/dpwspoon/npm-k3po#develop",
     "open": "0.0.5",
     "sinon": "^4.1.3",

--- a/test/http2-xhr-test.js
+++ b/test/http2-xhr-test.js
@@ -138,7 +138,7 @@ describe('http2-xhr', function () {
                 assert.equal(xhr.response, message);
             }
             if (xhr.readyState === 4 && xhr.status === 200) {
-                assert.equal(xhr.getResponseHeader('content-type'), 'text/html');
+                assert.equal(xhr.getResponseHeader('etag'), '123123');
                 assert.equal(xhr.getAllResponseHeaders(), 'content-type: text/html\ncontent-length: ' + message.length + '\ncache-control: private, max-age=0\ndate: ' + date + '\netag: 123123');
                 done();
             }


### PR DESCRIPTION
http://w3c-test.org/xhr/getresponseheader-chunked-trailer.htm

```
        var client = new XMLHttpRequest()
        client.onreadystatechange = function() {
          test.step(function() {
            if(client.readyState == 4) {
              assert_equals(client.getResponseHeader('Trailer'), 'X-Test-Me')
              assert_equals(client.getResponseHeader('X-Test-Me'), null)
              assert_equals(client.getAllResponseHeaders().indexOf('Trailer header value'), -1)
              assert_regexp_match(client.getAllResponseHeaders(), /trailer:\sX-Test-Me/)
              assert_equals(client.responseText, "First chunk\r\nSecond chunk\r\nYet another (third) chunk\r\nYet another (fourth) chunk\r\n")
              test.done()
            }
          })
        }
        client.open("GET", "resources/chunked.py")
        client.send(null)
      })

```