### PR TITLE
Better error handling to avoid block http2 streams from flowing

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -371,7 +371,7 @@ cp.validated = function (requestInfo, request) {
         var requestStreamIndex = revalidate.indexOf(requestStream);
 
         if (requestStreamIndex === -1) {
-            //Invalid state unable to validate
+            console.error('Invalid state unable to validate:' + requestStream);
             self._requestInfoRevalidating.delete(requestInfo.hash);
             return false;
         }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -371,7 +371,9 @@ cp.validated = function (requestInfo, request) {
         var requestStreamIndex = revalidate.indexOf(requestStream);
 
         if (requestStreamIndex === -1) {
-            throw new Error('Invalid state unable to validate:' + requestStream);
+            //Invalid state unable to validate
+            self._requestInfoRevalidating.delete(requestInfo.hash);
+            return false;
         }
 
         // Remove request from revalidate

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -24,8 +24,8 @@ var consoleLogger = {
         consoleLogger.debugLevel === 'trace' || 
           consoleLogger.debugLevel === 'debug'
     ) {
-        var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
-        debug.apply(console, args);
+      var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
+      debug.apply(console, args);
     } 
   },
   debug: function (data, ctx) {
@@ -34,8 +34,8 @@ var consoleLogger = {
       consoleLogger.debugLevel === 'trace' || 
         consoleLogger.debugLevel === 'debug'
     ) {
-        var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
-        debug.apply(console, args);
+      var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
+      debug.apply(console, args);
     } 
   },
   // Trace only

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -13,6 +13,7 @@ var defaultLogger = {
 };
 
 var consoleLogger = {
+  loggingEnabled: false,
   debugLevel: 'info', // 'info|debug|trace'
   fatal: console.error,
   error: console.error,
@@ -24,8 +25,11 @@ var consoleLogger = {
         consoleLogger.debugLevel === 'trace' || 
           consoleLogger.debugLevel === 'debug'
     ) {
-      var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
-      debug.apply(console, args);
+      if (loggingEnabled)
+        {
+            var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
+            debug.apply(console, args);
+        }
     } 
   },
   debug: function (data, ctx) {
@@ -34,8 +38,11 @@ var consoleLogger = {
       consoleLogger.debugLevel === 'trace' || 
         consoleLogger.debugLevel === 'debug'
     ) {
-      var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
-      debug.apply(console, args);
+      if (loggingEnabled)
+        {
+            var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
+            debug.apply(console, args);
+        }
     } 
   },
   // Trace only

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -13,7 +13,6 @@ var defaultLogger = {
 };
 
 var consoleLogger = {
-  loggingEnabled: false,
   debugLevel: 'info', // 'info|debug|trace'
   fatal: console.error,
   error: console.error,
@@ -25,11 +24,8 @@ var consoleLogger = {
         consoleLogger.debugLevel === 'trace' || 
           consoleLogger.debugLevel === 'debug'
     ) {
-      if (loggingEnabled)
-        {
-            var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
-            debug.apply(console, args);
-        }
+          var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
+          debug.apply(console, args);
     } 
   },
   debug: function (data, ctx) {
@@ -38,11 +34,8 @@ var consoleLogger = {
       consoleLogger.debugLevel === 'trace' || 
         consoleLogger.debugLevel === 'debug'
     ) {
-      if (loggingEnabled)
-        {
-            var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
-            debug.apply(console, args);
-        }
+          var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
+          debug.apply(console, args);
     } 
   },
   // Trace only

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -24,8 +24,8 @@ var consoleLogger = {
         consoleLogger.debugLevel === 'trace' || 
           consoleLogger.debugLevel === 'debug'
     ) {
-          var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
-          debug.apply(console, args);
+        var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
+        debug.apply(console, args);
     } 
   },
   debug: function (data, ctx) {
@@ -34,8 +34,8 @@ var consoleLogger = {
       consoleLogger.debugLevel === 'trace' || 
         consoleLogger.debugLevel === 'debug'
     ) {
-          var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
-          debug.apply(console, args);
+        var args = (typeof ctx === 'string' ? [ctx, data] : arguments);
+        debug.apply(console, args);
     } 
   },
   // Trace only

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -228,7 +228,6 @@ var dataToType = function (data, type) {
             if (typeof Blob !== 'undefined') {
                 return new Blob(data);
             } else {
-                //Unsupported Response Type
                 console.error("Unsupported Response Type: " + type);
                 return undefined;
             }
@@ -241,11 +240,12 @@ var dataToType = function (data, type) {
             ) {
                 return document.implementation.createDocument('http://www.w3.org/1999/xhtml', 'html', data);
             } else {
-                //Unsupported Response Type
+                console.error("Unsupported Response Type: " + type);
                 return undefined;
             }
             break;
         default:
+            console.error("Unexpected Response Type: " + type);
             return undefined;
     }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -208,7 +208,7 @@ var toArrayBuffer = function (buf) {
 var dataToType = function (data, type) {
 
     //if payload is missing don't throw runtime exception that will block h2 connection stream execution.
-    if (data == undefined) {
+    if (data === undefined) {
         console.error("Reieved response data is undefied");
         return undefined;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -206,6 +206,11 @@ var toArrayBuffer = function (buf) {
 };
 
 var dataToType = function (data, type) {
+
+    //if payload is missing don't throw runtime exception that will block h2 connection stream execution.
+    if (data == undefined) {
+        return undefined;
+    }
     // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType
     switch (type) {
         case "":
@@ -222,7 +227,8 @@ var dataToType = function (data, type) {
             if (typeof Blob !== 'undefined') {
                 return new Blob(data);
             } else {
-                throw new InvalidStateError("Unsupported Response Type: " + type);
+                //Unsupported Response Type
+                return undefined;
             }
             break;
         case "document":
@@ -233,11 +239,12 @@ var dataToType = function (data, type) {
             ) {
                 return document.implementation.createDocument('http://www.w3.org/1999/xhtml', 'html', data);
             } else {
-                throw new InvalidStateError("Unsupported Response Type: " + type);
+                //Unsupported Response Type
+                return undefined;
             }
             break;
         default:
-            throw new InvalidStateError("Unexpected Response Type: " + type);
+            return undefined;
     }
 };
 
@@ -324,5 +331,3 @@ module.exports = {
     mergeTypedArrays: mergeTypedArrays,
     Utf8ArrayToStr: Utf8ArrayToStr
 };
-
-

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -209,6 +209,7 @@ var dataToType = function (data, type) {
 
     //if payload is missing don't throw runtime exception that will block h2 connection stream execution.
     if (data == undefined) {
+        console.error("Reieved response data is undefied");
         return undefined;
     }
     // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType
@@ -228,6 +229,7 @@ var dataToType = function (data, type) {
                 return new Blob(data);
             } else {
                 //Unsupported Response Type
+                console.error("Unsupported Response Type: " + type);
                 return undefined;
             }
             break;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -208,7 +208,7 @@ var toArrayBuffer = function (buf) {
 var dataToType = function (data, type) {
 
     //if payload is missing don't throw runtime exception that will block h2 connection stream execution.
-    if (data === undefined) {
+    if (data == undefined) {
         console.error("Reieved response data is undefied");
         return undefined;
     }

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -337,7 +337,14 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
 
                 var transport = configuration.getTransport(proxyTransportUrl);
-
+                var wsErrorHandLer = function (/*e*/) {
+                    if (
+                        self.readyState === XMLHttpRequest.UNSENT &&
+                            options.accelerationStrategy === 'connected'
+                    ) {
+                        self.send();
+                    }
+                };
 
                 var request = http2.raw.request({
                     agent: configuration.agent,
@@ -477,18 +484,15 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 });
 
                 // Handle transport error and fallback
-                transport.on('error', function (/*e*/) {
-                    if (
-                        self.readyState === XMLHttpRequest.UNSENT &&
-                            options.accelerationStrategy === 'connected'
-                    ) {
-                        self.send();   
-                    }
-                });
+                transport.once('error', wsErrorHandLer);
 
                 // Update cache when receive pushRequest
                 request.on('push', function(respo) {
                     configuration.onPush(respo);
+                });
+
+                request.once('finish', function() {
+                    transport.removeListener("error", wsErrorHandLer);
                 });
                 
                 request.end(body || null);

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -199,6 +199,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 break;
             default:
                 configuration._log.error("Unexpected XHR _changeState: " + state);
+                return;
         }
 
         switch (state) {
@@ -209,6 +210,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             this.readyState = state;
             if (this.readyState !== state) {
                 configuration._log.error('Unable to update readyState ' +  this.readyState + ' vs ' + state);
+                return;
             }
         }
         this.__dispatchEvent(new ProgressEvent('readystatechange'));
@@ -228,6 +230,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             var responseType = xhrInfo.get(xhr, 'responseType') || '';
             if (responseType !== '' && responseType !== 'text') {
                 configuration._log.error("Failed to read the 'responseText' property from 'XMLHttpRequest': The value is only accessible if the object's 'responseType' is '' or 'text' (was '" + responseType + "')");
+                return undefined;
             }
 
             // Force text rendering

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -338,10 +338,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
                 var transport = configuration.getTransport(proxyTransportUrl);
                 var wsErrorHandLer = function (/*e*/) {
-                    if (
-                        self.readyState === XMLHttpRequest.UNSENT &&
-                            options.accelerationStrategy === 'connected'
-                    ) {
+                    if (self.readyState === XMLHttpRequest.UNSENT && options.accelerationStrategy === 'connected') {
                         self.send();
                     }
                 };

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -198,7 +198,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
                 this.__dispatchEvent(new ProgressEvent('loadend'));
                 break;
             default:
-                throw new InvalidStateError("Unexpected XHR _changeState: " + state);
+                configuration._log.error("Unexpected XHR _changeState: " + state);
         }
 
         switch (state) {
@@ -208,7 +208,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
             default:
             this.readyState = state;
             if (this.readyState !== state) {
-                throw new Error('Unable to update readyState ' +  this.readyState + ' vs ' + state);
+                configuration._log.error('Unable to update readyState ' +  this.readyState + ' vs ' + state);
             }
         }
         this.__dispatchEvent(new ProgressEvent('readystatechange'));
@@ -227,7 +227,7 @@ function enableXHROverH2(XMLHttpRequest, configuration) {
 
             var responseType = xhrInfo.get(xhr, 'responseType') || '';
             if (responseType !== '' && responseType !== 'text') {
-                throw new InvalidStateError("Failed to read the 'responseText' property from 'XMLHttpRequest': The value is only accessible if the object's 'responseType' is '' or 'text' (was '" + responseType + "')");
+                configuration._log.error("Failed to read the 'responseText' property from 'XMLHttpRequest': The value is only accessible if the object's 'responseType' is '' or 'text' (was '" + responseType + "')");
             }
 
             // Force text rendering


### PR DESCRIPTION
For some yet to be identified reason, the response coming from RA doesn't contain the payload and the client always expects to have payload. So when the client tries to decode the missing payload it throws an error which makes the connection stream to stop flowing. There are few more cases where the client is throwing run time exception in side the http2 closures that causes the streams stop execution.